### PR TITLE
feat: display error notification on request failure

### DIFF
--- a/src/features/common/error.middleware.ts
+++ b/src/features/common/error.middleware.ts
@@ -1,0 +1,19 @@
+import type { Action, Middleware, MiddlewareAPI } from '@reduxjs/toolkit';
+import { isRejectedWithValue } from '@reduxjs/toolkit';
+
+import { addNotification } from '@/features/notifications/notifications.slice';
+
+const middleware: Middleware = function errorMiddleware(api: MiddlewareAPI) {
+  return (next) => {
+    return (action: Action) => {
+      if (isRejectedWithValue(action)) {
+        const message = action.error.message;
+        api.dispatch(addNotification({ message, type: 'negative' }));
+      }
+
+      return next(action);
+    };
+  };
+};
+
+export default middleware;

--- a/src/features/common/store.ts
+++ b/src/features/common/store.ts
@@ -5,6 +5,7 @@ import type { TypedUseSelectorHook } from 'react-redux';
 import { useDispatch, useSelector } from 'react-redux';
 
 import entitiesReducer from '@/features/common/entities.slice';
+import errorMiddleware from '@/features/common/error.middleware';
 import intaviaApiService from '@/features/common/intavia-api.service';
 import notificationsReducer from '@/features/notifications/notifications.slice';
 
@@ -15,7 +16,7 @@ export const store = configureStore({
     [intaviaApiService.reducerPath]: intaviaApiService.reducer,
   },
   middleware(getDefaultMiddleware) {
-    return getDefaultMiddleware().concat(intaviaApiService.middleware);
+    return getDefaultMiddleware().concat(intaviaApiService.middleware, errorMiddleware);
   },
 });
 


### PR DESCRIPTION
this adds a redux middleware to display error notifications in case of request failures.

in the future we probably want to deduplicate error notifications for the same `queryCacheKey` (e.g. to avoid displaying multiple notifications on retry failures), but should be ok for now.