### PR TITLE
fix: use date strings in mock db

### DIFF
--- a/app.d.ts
+++ b/app.d.ts
@@ -1,1 +1,3 @@
 type Optional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+
+type IsoDateString = string;

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "types": ["cypress", "@testing-library/cypress"]
   },
-  "include": ["./**/*.ts", "./**/*.tsx", "../src/mocks/mocks.browser.ts"],
+  "include": ["./**/*.ts", "./**/*.tsx", "../app.d.ts", "../src/mocks/mocks.browser.ts"],
   "exclude": []
 }

--- a/src/features/common/entity.model.ts
+++ b/src/features/common/entity.model.ts
@@ -8,7 +8,7 @@ export interface EntityBase {
 export interface Relation {
   type: string;
   targetId?: Entity['id'];
-  date?: Date;
+  date?: IsoDateString;
   placeId?: Place['id'];
 }
 

--- a/src/mocks/db.ts
+++ b/src/mocks/db.ts
@@ -58,12 +58,12 @@ function createLifeSpanRelations(): Array<Relation> {
   return [
     {
       type: 'beginning',
-      date: dateOfBirth,
+      date: dateOfBirth.toISOString(),
       placeId: faker.random.arrayElement(db.place.getIds()),
     },
     {
       type: 'end',
-      date: dateOfDeath,
+      date: dateOfDeath.toISOString(),
       placeId: faker.random.arrayElement(db.place.getIds()),
     },
   ];
@@ -81,7 +81,7 @@ function createPersonRelation(type: string, targetId: Entity['id'], date?: Date)
       type,
       targetId,
       placeId: faker.random.arrayElement(db.place.getIds()),
-      date,
+      date: date.toISOString(),
     };
   }
 }
@@ -154,11 +154,13 @@ export function seed() {
     ) {
       //overlapping dates
       relationType = 'was in contact with';
-      const start = new Date(
-        Math.max(sourcePersonDateOfBirth.getTime(), targetPersonDateOfBirth.getTime()),
+      const start = Math.max(
+        new Date(sourcePersonDateOfBirth).getTime(),
+        new Date(targetPersonDateOfBirth).getTime(),
       );
-      const end = new Date(
-        Math.min(sourcePersonDateOfDeath.getTime(), targetPersonDateOfDeath.getTime()),
+      const end = Math.min(
+        new Date(sourcePersonDateOfDeath).getTime(),
+        new Date(targetPersonDateOfDeath).getTime(),
       );
       relationDate = faker.date.between(start, end);
     } else {


### PR DESCRIPTION
fixes #13

the (mock) api will stringify any dates in the (mock) database - this adjusts the model types to reflect that.