### PR TITLE
refactor: import leaflet css from package, not from cdn

### DIFF
--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -1,3 +1,4 @@
+import 'leaflet/dist/leaflet.css';
 import '@/styles/index.css';
 
 import type { EmotionCache } from '@emotion/cache';

--- a/src/pages/_document.page.tsx
+++ b/src/pages/_document.page.tsx
@@ -13,12 +13,6 @@ export default class Document extends NextDocument<{ emotionStyleTags: Array<JSX
             href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
             crossOrigin="anonymous"
           />
-          <link
-            rel="stylesheet"
-            href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css"
-            integrity="sha512-xodZBNTC5n17Xt2atTPuE1HxjVMSvLVW9ocqUKLsCC5CXdbqCmblAshOMAS6/keqq/sMZMZ19scR4PsZChSR7A=="
-            crossOrigin=""
-          />
           {this.props.emotionStyleTags}
         </Head>
         <body>


### PR DESCRIPTION
currently, we import the leaflet css via `link` tag from cdn. this pr changes that to import directly from the `leaflet` package. leaflet css is added globally.