### PR TITLE
Fix TextConstraintView react error

### DIFF
--- a/src/features/visual-querying/ConstraintList.tsx
+++ b/src/features/visual-querying/ConstraintList.tsx
@@ -40,6 +40,7 @@ export function ConstraintList(props: ConstraintListProps) {
         opened: true,
         type: type,
         dateRange: null,
+        text: '',
       } as Constraint),
     );
   }

--- a/src/features/visual-querying/visualQuerying.slice.ts
+++ b/src/features/visual-querying/visualQuerying.slice.ts
@@ -27,7 +27,7 @@ export interface DateConstraint extends Constraint {
 
 export interface TextConstraint extends Constraint {
   type: ConstraintType.Name;
-  text: string | null;
+  text: string;
 }
 
 export interface VisualQueryingState {
@@ -72,7 +72,7 @@ const visualQueryingSlice = createSlice({
         constraint.dateRange = action.payload.dateRange;
       }
     },
-    updateText: (state, action: PayloadAction<{ id: string; text: string | null }>) => {
+    updateText: (state, action: PayloadAction<{ id: string; text: string }>) => {
       const constraint = state.constraints.find((constraint) => {
         return constraint.id === action.payload.id && constraint.type === ConstraintType.Name;
       }) as TextConstraint | undefined;


### PR DESCRIPTION
TextConstraints are now initialized with an empty string as the value of the text attribute. This prevents the text field in the TextConstraintView from switching from an uncontrolled input to a controlled input as the user enters text.

closes #57 