### PR TITLE
[VQ] add a profession hierarchy

### DIFF
--- a/src/features/common/entity.model.ts
+++ b/src/features/common/entity.model.ts
@@ -18,10 +18,15 @@ export interface EntityEvent {
 // FIXME: remove
 export type Relation = Omit<EntityEvent, 'type'> & { type: string };
 
+export interface Profession {
+  name: string;
+  parent: string | null;
+}
+
 export interface Person extends EntityBase {
   kind: 'person';
   gender: string;
-  occupation: Array<string>;
+  occupation: Array<Profession['name']>;
   categories: Array<string>;
 }
 

--- a/src/features/common/intavia-api.service.ts
+++ b/src/features/common/intavia-api.service.ts
@@ -2,7 +2,7 @@ import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 import { createUrlSearchParams } from '@stefanprobst/request';
 import type { Bin } from 'd3-array';
 
-import type { Entity, Person, Place } from '@/features/common/entity.model';
+import type { Entity, Person, Place, Profession } from '@/features/common/entity.model';
 import { baseUrl } from '~/config/intavia.config';
 
 export interface PaginatedEntitiesResponse<T extends Entity> {
@@ -88,6 +88,20 @@ const service = createApi({
           return { url: `/api/places/${id}` };
         },
       }),
+      getProfessions: builder.query<
+        Array<Profession & { count: number }>,
+        {
+          q?: string;
+          dateOfBirthStart?: number;
+          dateOfBirthEnd?: number;
+          dateOfDeathStart?: number;
+          dateOfDeathEnd?: number;
+        }
+      >({
+        query(params) {
+          return { url: '/api/professions/statistics', params };
+        },
+      }),
     };
   },
 });
@@ -99,5 +113,6 @@ export const {
   useGetPlacesQuery,
   useGetPlaceByIdQuery,
   useGetPersonDistributionByPropertyQuery,
+  useGetProfessionsQuery,
 } = service;
 export default service;

--- a/src/features/common/intavia-api.service.ts
+++ b/src/features/common/intavia-api.service.ts
@@ -34,6 +34,7 @@ const service = createApi({
           dateOfBirthEnd?: number;
           dateOfDeathStart?: number;
           dateOfDeathEnd?: number;
+          professions?: string;
         }
       >({
         query(params) {
@@ -44,11 +45,20 @@ const service = createApi({
             dateOfBirthEnd,
             dateOfDeathStart,
             dateOfDeathEnd,
+            professions,
           } = params;
 
           return {
             url: '/api/persons',
-            params: { page, q, dateOfBirthStart, dateOfBirthEnd, dateOfDeathStart, dateOfDeathEnd },
+            params: {
+              page,
+              q,
+              dateOfBirthStart,
+              dateOfBirthEnd,
+              dateOfDeathStart,
+              dateOfDeathEnd,
+              professions,
+            },
           };
         },
       }),
@@ -96,6 +106,7 @@ const service = createApi({
           dateOfBirthEnd?: number;
           dateOfDeathStart?: number;
           dateOfDeathEnd?: number;
+          professions?: string;
         }
       >({
         query(params) {

--- a/src/features/layouts/PageLayout.tsx
+++ b/src/features/layouts/PageLayout.tsx
@@ -8,6 +8,7 @@ import TimelineIcon from '@mui/icons-material/LinearScale';
 import MapIcon from '@mui/icons-material/MapOutlined';
 import MenuIcon from '@mui/icons-material/Menu';
 import SearchIcon from '@mui/icons-material/SearchOutlined';
+import ProfessionsIcon from '@mui/icons-material/Work';
 import type { AppBarProps as MuiAppBarProps } from '@mui/material/AppBar';
 import MuiAppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
@@ -53,6 +54,12 @@ export function PageLayout(props: PageLayoutProps): JSX.Element {
       icon: <CollectionsOutlinedIcon />,
     },
     { id: 'timeline', href: { pathname: '/timeline' }, label: 'Timeline', icon: <TimelineIcon /> },
+    {
+      id: 'professions',
+      href: { pathname: '/professions' },
+      label: 'Profession Hierarchy',
+      icon: <ProfessionsIcon />,
+    },
     { id: 'map', href: { pathname: '/geomap' }, label: 'Map', icon: <MapIcon /> },
     {
       id: 'coordination',

--- a/src/features/professions/profession-hierarchy-node.tsx
+++ b/src/features/professions/profession-hierarchy-node.tsx
@@ -27,13 +27,16 @@ export interface ProfessionHierarchyNodeProps {
 export function ProfessionHierarchyNode(
   props: ProfessionHierarchyNodeProps,
 ): JSX.Element {
-  const { label, x0, x1, y0, y1, color, personIds, scaleX, scaleY, renderLabel, hovered, setHovered, ...extraProps } = props;
+  const { label, color, renderLabel } = props;
+  const { x0, x1, y0, y1, scaleX, scaleY } = props;
+  const { personIds, hovered, setHovered } = props;
 
   const x = scaleX(x0);
   const width = scaleX(x1) - x;
   const y = scaleY(y0);
   const height = scaleY(y1) - y;
 
+  // only render label if set to be rendered AND enough vertical space to do so
   const reallyRenderLabel = renderLabel && height > 14;
 
   const handleMouseEnter = (entityIds: Array<Person['id']>) => {

--- a/src/features/professions/profession-hierarchy-node.tsx
+++ b/src/features/professions/profession-hierarchy-node.tsx
@@ -2,7 +2,7 @@ import { lch } from 'd3-color';
 import type { ScaleLinear } from 'd3-scale';
 
 import type { Person } from '@/features/common/entity.model';
-import type { ToggleProfessionFn } from '@/features/professions/Professions';
+import type { ToggleProfessionFn } from '@/features/professions/professions';
 
 export interface ProfessionHierarchyNodeProps {
   label: string;
@@ -56,11 +56,15 @@ export function ProfessionHierarchyNode(props: ProfessionHierarchyNodeProps): JS
       }}
       // onMouseLeave={handleMouseLeave}
       onClick={() => {
-        selectable && toggleProfession(professionIds, !selected);
+        selectable && toggleProfession(professionIds);
       }}
-      style={!selectable ? {
-        cursor: 'pointer',
-      } : {}}
+      style={
+        selectable
+          ? {
+              cursor: 'pointer',
+            }
+          : {}
+      }
     >
       <title>
         {label}: {personIds.length} persons
@@ -74,7 +78,10 @@ export function ProfessionHierarchyNode(props: ProfessionHierarchyNodeProps): JS
       {selectable && selected && (
         <>
           {/* checkbox */}
-          <path fill="black" d={`M ${x + width} ${y + height} m -20 -12 l 2 -2 4 4 8 -8 2 2 -10 10 -6 -6 z`} />
+          <path
+            fill={labelColor}
+            d={`M ${x + width} ${y + height} m -20 -12 l 2 -2 4 4 8 -8 2 2 -10 10 -6 -6 z`}
+          />
         </>
       )}
     </g>

--- a/src/features/professions/profession-hierarchy-node.tsx
+++ b/src/features/professions/profession-hierarchy-node.tsx
@@ -2,6 +2,7 @@ import { lch } from 'd3-color';
 import type { ScaleLinear } from 'd3-scale';
 
 import type { Person } from '@/features/common/entity.model';
+import type { ToggleProfessionFn } from '@/features/professions/Professions';
 
 export interface ProfessionHierarchyNodeProps {
   label: string;
@@ -16,12 +17,18 @@ export interface ProfessionHierarchyNodeProps {
   renderLabel: boolean;
   hovered?: Array<Person['id']> | null;
   setHovered?: (val: Array<Person['id']> | null) => void;
+  professionIds: Array<string>;
+
+  selectable: boolean;
+  selected: boolean;
+  toggleProfession: ToggleProfessionFn;
 }
 
 export function ProfessionHierarchyNode(props: ProfessionHierarchyNodeProps): JSX.Element {
   const { label, color, renderLabel } = props;
   const { x0, x1, y0, y1, scaleX, scaleY } = props;
-  const { personIds, setHovered } = props;
+  const { personIds, professionIds, setHovered } = props;
+  const { selected, selectable, toggleProfession } = props;
 
   const x = scaleX(x0);
   const width = scaleX(x1) - x;
@@ -48,6 +55,12 @@ export function ProfessionHierarchyNode(props: ProfessionHierarchyNodeProps): JS
         return handleMouseEnter(personIds);
       }}
       // onMouseLeave={handleMouseLeave}
+      onClick={() => {
+        selectable && toggleProfession(professionIds, !selected);
+      }}
+      style={!selectable ? {
+        cursor: 'pointer',
+      } : {}}
     >
       <title>
         {label}: {personIds.length} persons
@@ -57,6 +70,12 @@ export function ProfessionHierarchyNode(props: ProfessionHierarchyNodeProps): JS
         <text fill={labelColor} x={x + width / 2} y={y + height / 2} dy="0.3em" textAnchor="middle">
           {label}
         </text>
+      )}
+      {selectable && selected && (
+        <>
+          {/* checkbox */}
+          <path fill="black" d={`M ${x + width} ${y + height} m -20 -12 l 2 -2 4 4 8 -8 2 2 -10 10 -6 -6 z`} />
+        </>
       )}
     </g>
   );

--- a/src/features/professions/profession-hierarchy-node.tsx
+++ b/src/features/professions/profession-hierarchy-node.tsx
@@ -1,13 +1,7 @@
-import { max } from 'd3-array';
-import { color as d3color, lch } from 'd3-color';
-import type { ScaleBand, ScaleTime } from 'd3-scale';
-import { scaleOrdinal } from 'd3-scale';
-import { schemeTableau10 } from 'd3-scale-chromatic';
-import type { ForwardedRef } from 'react';
-import { forwardRef } from 'react';
+import { lch } from 'd3-color';
+import type { ScaleLinear } from 'd3-scale';
 
 import type { Person } from '@/features/common/entity.model';
-import { eventTypes } from '@/features/common/event-types';
 
 export interface ProfessionHierarchyNodeProps {
   label: string;
@@ -15,8 +9,8 @@ export interface ProfessionHierarchyNodeProps {
   y0: number;
   x1: number;
   y1: number;
-  scaleX: ScaleLinear<number>;
-  scaleY: ScaleLinear<number>;
+  scaleX: ScaleLinear<number, number>;
+  scaleY: ScaleLinear<number, number>;
   color: string;
   personIds: Array<Person['id']>;
   renderLabel: boolean;
@@ -24,12 +18,10 @@ export interface ProfessionHierarchyNodeProps {
   setHovered?: (val: Array<Person['id']> | null) => void;
 }
 
-export function ProfessionHierarchyNode(
-  props: ProfessionHierarchyNodeProps,
-): JSX.Element {
+export function ProfessionHierarchyNode(props: ProfessionHierarchyNodeProps): JSX.Element {
   const { label, color, renderLabel } = props;
   const { x0, x1, y0, y1, scaleX, scaleY } = props;
-  const { personIds, hovered, setHovered } = props;
+  const { personIds, setHovered } = props;
 
   const x = scaleX(x0);
   const width = scaleX(x1) - x;
@@ -46,7 +38,7 @@ export function ProfessionHierarchyNode(
   // const handleMouseLeave = () => {
   //   setHovered?.(null);
   // };
-  const backgroundLightness = lch(d3color(color)).l;
+  const backgroundLightness = lch(color).l;
   const labelColor = backgroundLightness < 45 ? 'white' : 'black';
 
   return (
@@ -57,24 +49,12 @@ export function ProfessionHierarchyNode(
       }}
       // onMouseLeave={handleMouseLeave}
     >
-      <title>{label}: {personIds.length} persons</title>
-      <rect
-        stroke="white"
-        strokeWidth={1}
-        fill={color}
-        x={x}
-        width={width}
-        y={y}
-        height={height}
-      />
+      <title>
+        {label}: {personIds.length} persons
+      </title>
+      <rect stroke="white" strokeWidth={1} fill={color} x={x} width={width} y={y} height={height} />
       {reallyRenderLabel && (
-        <text
-          fill={labelColor}
-          x={x + width / 2}
-          y={y + height / 2}
-          dy="0.3em"
-          textAnchor="middle"
-        >
+        <text fill={labelColor} x={x + width / 2} y={y + height / 2} dy="0.3em" textAnchor="middle">
           {label}
         </text>
       )}

--- a/src/features/professions/profession-hierarchy-node.tsx
+++ b/src/features/professions/profession-hierarchy-node.tsx
@@ -1,0 +1,80 @@
+import { max } from 'd3-array';
+import { color as d3color, lch } from 'd3-color';
+import type { ScaleBand, ScaleTime } from 'd3-scale';
+import { scaleOrdinal } from 'd3-scale';
+import { schemeTableau10 } from 'd3-scale-chromatic';
+import type { ForwardedRef } from 'react';
+import { forwardRef } from 'react';
+
+import type { Person } from '@/features/common/entity.model';
+import { eventTypes } from '@/features/common/event-types';
+
+export interface ProfessionHierarchyNodeProps {
+  label: string;
+  x0: number;
+  y0: number;
+  x1: number;
+  y1: number;
+  scaleX: ScaleLinear<number>;
+  scaleY: ScaleLinear<number>;
+  color: string;
+  personIds: Array<Person['id']>;
+  renderLabel: boolean;
+  hovered?: Array<Person['id']> | null;
+  setHovered?: (val: Array<Person['id']> | null) => void;
+}
+
+export function ProfessionHierarchyNode(
+  props: ProfessionHierarchyNodeProps,
+): JSX.Element {
+  const { label, x0, x1, y0, y1, color, personIds, scaleX, scaleY, renderLabel, hovered, setHovered, ...extraProps } = props;
+
+  const x = scaleX(x0);
+  const width = scaleX(x1) - x;
+  const y = scaleY(y0);
+  const height = scaleY(y1) - y;
+
+  const reallyRenderLabel = renderLabel && height > 14;
+
+  const handleMouseEnter = (entityIds: Array<Person['id']>) => {
+    setHovered?.(entityIds);
+  };
+
+  // const handleMouseLeave = () => {
+  //   setHovered?.(null);
+  // };
+  const backgroundLightness = lch(d3color(color)).l;
+  const labelColor = backgroundLightness < 45 ? 'white' : 'black';
+
+  return (
+    <g
+      id={`profession-${label}`}
+      onMouseEnter={() => {
+        return handleMouseEnter(personIds);
+      }}
+      // onMouseLeave={handleMouseLeave}
+    >
+      <title>{label}: {personIds.length} persons</title>
+      <rect
+        stroke="white"
+        strokeWidth={1}
+        fill={color}
+        x={x}
+        width={width}
+        y={y}
+        height={height}
+      />
+      {reallyRenderLabel && (
+        <text
+          fill={labelColor}
+          x={x + width / 2}
+          y={y + height / 2}
+          dy="0.3em"
+          textAnchor="middle"
+        >
+          {label}
+        </text>
+      )}
+    </g>
+  );
+}

--- a/src/features/professions/profession-hierarchy-node.tsx
+++ b/src/features/professions/profession-hierarchy-node.tsx
@@ -1,7 +1,7 @@
 import { hsl, lch } from 'd3-color';
 import type { ScaleLinear } from 'd3-scale';
 
-import type { Person } from '@/features/common/entity.model';
+import type { Profession } from '@/features/common/entity.model';
 import type { ToggleProfessionFn } from '@/features/professions/professions';
 import { LeafSizing } from '@/features/professions/professions-svg';
 
@@ -16,13 +16,11 @@ export interface ProfessionHierarchyNodeProps {
   colorForeground: string;
   colorBackground: string;
   isLeaf: boolean;
-  personIds: Array<Person['id']>;
   renderLabel: boolean;
-  hovered?: Array<Person['id']> | null;
-  setHovered?: (val: Array<Person['id']> | null) => void;
   professionIds: Array<string>;
   leafSizing: LeafSizing;
   barWidth: number;
+  profession: Profession & { count: number };
 
   selectable: boolean;
   selected: boolean;
@@ -33,7 +31,7 @@ export function ProfessionHierarchyNode(props: ProfessionHierarchyNodeProps): JS
   const { label, colorForeground, colorBackground, renderLabel } = props;
   const { isLeaf, leafSizing, barWidth } = props;
   const { x0, x1, y0, y1, scaleX, scaleY } = props;
-  const { personIds, professionIds, setHovered } = props;
+  const { profession, professionIds } = props;
   const { selected, selectable, toggleProfession } = props;
 
   const x = scaleX(x0);
@@ -44,13 +42,6 @@ export function ProfessionHierarchyNode(props: ProfessionHierarchyNodeProps): JS
   // only render label if set to be rendered AND enough vertical space to do so
   const reallyRenderLabel = renderLabel && height > 14;
 
-  const handleMouseEnter = (entityIds: Array<Person['id']>) => {
-    setHovered?.(entityIds);
-  };
-
-  // const handleMouseLeave = () => {
-  //   setHovered?.(null);
-  // };
   const backgroundLightness = lch(colorBackground).l;
   const labelColor = backgroundLightness < 45 ? 'white' : 'black';
   const fg = hsl(colorForeground);
@@ -59,10 +50,6 @@ export function ProfessionHierarchyNode(props: ProfessionHierarchyNodeProps): JS
   return (
     <g
       id={`profession-${label}`}
-      onMouseEnter={() => {
-        return handleMouseEnter(personIds);
-      }}
-      // onMouseLeave={handleMouseLeave}
       onClick={() => {
         selectable && toggleProfession(professionIds);
       }}
@@ -75,7 +62,7 @@ export function ProfessionHierarchyNode(props: ProfessionHierarchyNodeProps): JS
       }
     >
       <title>
-        {label}: {personIds.length} persons
+        {label}: {profession.count} persons
       </title>
       <rect
         stroke="white"

--- a/src/features/professions/profession-hierarchy-node.tsx
+++ b/src/features/professions/profession-hierarchy-node.tsx
@@ -27,6 +27,13 @@ export interface ProfessionHierarchyNodeProps {
   toggleProfession: ToggleProfessionFn;
 }
 
+/**
+ * Rectangular node with background, label, maybe an extra bar chart bar, and
+ * maybe a tick mark. The bar is only drawn in the `QualitativeWithBar`
+ * `LeafSizing` mode, and the tick mark (and click interactions) are only
+ * available in the `selectable` mode, when the `Professions` element is used
+ * as a scented widget.
+ */
 export function ProfessionHierarchyNode(props: ProfessionHierarchyNodeProps): JSX.Element {
   const { label, colorForeground, colorBackground, renderLabel } = props;
   const { isLeaf, leafSizing, barWidth } = props;
@@ -89,14 +96,12 @@ export function ProfessionHierarchyNode(props: ProfessionHierarchyNodeProps): JS
           {label}
         </text>
       )}
+      {/* checkbox */}
       {selectable && selected && (
-        <>
-          {/* checkbox */}
-          <path
-            fill={labelColor}
-            d={`M ${x + width} ${y + height} m -20 -12 l 2 -2 4 4 8 -8 2 2 -10 10 -6 -6 z`}
-          />
-        </>
+        <path
+          fill={labelColor}
+          d={`M ${x + width} ${y + height} m -20 -12 l 2 -2 4 4 8 -8 2 2 -10 10 -6 -6 z`}
+        />
       )}
     </g>
   );

--- a/src/features/professions/profession-hierarchy-node.tsx
+++ b/src/features/professions/profession-hierarchy-node.tsx
@@ -1,8 +1,9 @@
-import { lch } from 'd3-color';
+import { hsl, lch } from 'd3-color';
 import type { ScaleLinear } from 'd3-scale';
 
 import type { Person } from '@/features/common/entity.model';
 import type { ToggleProfessionFn } from '@/features/professions/professions';
+import { LeafSizing } from '@/features/professions/professions-svg';
 
 export interface ProfessionHierarchyNodeProps {
   label: string;
@@ -12,12 +13,16 @@ export interface ProfessionHierarchyNodeProps {
   y1: number;
   scaleX: ScaleLinear<number, number>;
   scaleY: ScaleLinear<number, number>;
-  color: string;
+  colorForeground: string;
+  colorBackground: string;
+  isLeaf: boolean;
   personIds: Array<Person['id']>;
   renderLabel: boolean;
   hovered?: Array<Person['id']> | null;
   setHovered?: (val: Array<Person['id']> | null) => void;
   professionIds: Array<string>;
+  leafSizing: LeafSizing;
+  barWidth: number;
 
   selectable: boolean;
   selected: boolean;
@@ -25,7 +30,8 @@ export interface ProfessionHierarchyNodeProps {
 }
 
 export function ProfessionHierarchyNode(props: ProfessionHierarchyNodeProps): JSX.Element {
-  const { label, color, renderLabel } = props;
+  const { label, colorForeground, colorBackground, renderLabel } = props;
+  const { isLeaf, leafSizing, barWidth } = props;
   const { x0, x1, y0, y1, scaleX, scaleY } = props;
   const { personIds, professionIds, setHovered } = props;
   const { selected, selectable, toggleProfession } = props;
@@ -45,8 +51,10 @@ export function ProfessionHierarchyNode(props: ProfessionHierarchyNodeProps): JS
   // const handleMouseLeave = () => {
   //   setHovered?.(null);
   // };
-  const backgroundLightness = lch(color).l;
+  const backgroundLightness = lch(colorBackground).l;
   const labelColor = backgroundLightness < 45 ? 'white' : 'black';
+  const fg = hsl(colorForeground);
+  const frameColor = hsl(fg.h, 0.3, 0.3).toString();
 
   return (
     <g
@@ -69,7 +77,26 @@ export function ProfessionHierarchyNode(props: ProfessionHierarchyNodeProps): JS
       <title>
         {label}: {personIds.length} persons
       </title>
-      <rect stroke="white" strokeWidth={1} fill={color} x={x} width={width} y={y} height={height} />
+      <rect
+        stroke="white"
+        strokeWidth={1}
+        fill={colorBackground}
+        x={x}
+        width={width}
+        y={y}
+        height={height}
+      />
+      {isLeaf && leafSizing === LeafSizing.QualitativeWithBar && (
+        <rect
+          stroke={frameColor}
+          strokeWidth={1}
+          fill={colorForeground}
+          x={x + 1}
+          width={width * barWidth - 2}
+          y={y + 1}
+          height={height - 2}
+        />
+      )}
       {reallyRenderLabel && (
         <text fill={labelColor} x={x + width / 2} y={y + height / 2} dy="0.3em" textAnchor="middle">
           {label}

--- a/src/features/professions/professions-page-header.tsx
+++ b/src/features/professions/professions-page-header.tsx
@@ -1,0 +1,14 @@
+import Box from '@mui/material/Box';
+
+import { PageTitle } from '@/features/ui/page-title';
+
+export function ProfessionsPageHeader(): JSX.Element {
+  return (
+    <Box
+      component="header"
+      sx={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between' }}
+    >
+      <PageTitle>Profession Hierarchy</PageTitle>
+    </Box>
+  );
+}

--- a/src/features/professions/professions-svg.tsx
+++ b/src/features/professions/professions-svg.tsx
@@ -11,8 +11,8 @@ import { useEffect, useState } from 'react';
 
 import type { Person } from '@/features/common/entity.model';
 import { ProfessionHierarchyNode } from '@/features/professions/profession-hierarchy-node';
+import type { ToggleProfessionFn } from '@/features/professions/professions';
 import type { ProfessionConstraint } from '@/features/visual-querying/visualQuerying.slice';
-import type { ToggleProfessionFn } from '@/features/professions/professions.tsx';
 
 export enum LeafSizing {
   Qualitative,
@@ -122,9 +122,20 @@ export function ProfessionsSvg(props: ProfessionsSvgProps): JSX.Element {
     >
       {allButRootNode.map((node) => {
         const label = node.data.label === noOccupation ? 'no occupation' : node.data.label;
-        const professionIds = node.data.label === noOccupation
-          ? []
-          : node.descendants().filter(d => (d.children?.length ?? 0) === 0).map(d => d.data.label);
+        const professionIds: Array<string> =
+          node.data.label === noOccupation
+            ? []
+            : (node
+                .descendants()
+                .filter((d) => {
+                  return (d.children?.length ?? 0) === 0;
+                })
+                .map((d) => {
+                  return d.data.label;
+                })
+                .filter((d) => {
+                  return typeof d === 'string';
+                }) as Array<string>);
 
         return (
           <ProfessionHierarchyNode
@@ -142,9 +153,8 @@ export function ProfessionsSvg(props: ProfessionsSvgProps): JSX.Element {
             setHovered={setHovered}
             label={label}
             color={colorMap.get(node.data.label) ?? 'hotpink'}
-
-            selectable={!!constraint}
-            selected={constraint?.selection?.has(node.data.label) ?? false}
+            selectable={Boolean(constraint)}
+            selected={constraint?.selection?.includes(node.data.label as string) ?? false}
             toggleProfession={toggleProfession}
           />
         );

--- a/src/features/professions/professions-svg.tsx
+++ b/src/features/professions/professions-svg.tsx
@@ -12,6 +12,7 @@ import { useEffect, useState } from 'react';
 import type { Person } from '@/features/common/entity.model';
 import { ProfessionHierarchyNode } from '@/features/professions/profession-hierarchy-node';
 import type { ToggleProfessionFn } from '@/features/professions/professions';
+import { Origin } from '@/features/visual-querying/Origin';
 import type { ProfessionConstraint } from '@/features/visual-querying/visualQuerying.slice';
 
 export enum LeafSizing {
@@ -28,6 +29,7 @@ interface ProfessionsSvgProps {
   setHovered?: (val: Array<Person['id']> | null) => void;
   constraint?: ProfessionConstraint;
   toggleProfession: ToggleProfessionFn;
+  origin: Origin;
 }
 
 const svgMinWidth = 300;
@@ -57,6 +59,9 @@ export function ProfessionsSvg(props: ProfessionsSvgProps): JSX.Element {
     return d.depth > 0;
   });
 
+  // do not use origin, svg must have viewBox starting at 0 0
+  const origin = new Origin();
+
   // x is y, y is x
   const dataXRange: [number, number] = extent<number>(
     allButRootNode
@@ -68,8 +73,8 @@ export function ProfessionsSvg(props: ProfessionsSvgProps): JSX.Element {
 
   const xScale = scaleLinear()
     .domain(dataXRange)
-    .range([20, svgWidth - 20]);
-  const yScale = scaleLinear().range([20, svgHeight - 20]);
+    .range([origin.x(20), origin.x(svgWidth - 20)]);
+  const yScale = scaleLinear().range([origin.y(20), origin.y(svgHeight - 20)]);
 
   // store colors per node in a map
   const colorMap = new Map<NoOccupation | string, string>();

--- a/src/features/professions/professions-svg.tsx
+++ b/src/features/professions/professions-svg.tsx
@@ -200,7 +200,7 @@ function createHierarchy(
   const leafSizeFn =
     leafSizing === LeafSizing.Quantitative
       ? (node: _HierarchyData): number => {
-          return node.count;
+          return leaves.includes(node.name) ? node.count : 0;
         }
       : (node: _HierarchyData): number => {
           return leaves.includes(node.name) ? 1 : 0;

--- a/src/features/professions/professions-svg.tsx
+++ b/src/features/professions/professions-svg.tsx
@@ -1,5 +1,7 @@
 //import { extent } from 'd3-array';
-//import { scaleBand, scaleTime } from 'd3-scale';
+import { scaleLinear } from 'd3-scale';
+import { hierarchy, partition } from 'd3-hierarchy';
+import { group } from 'd3-array';
 import type { MutableRefObject } from 'react';
 import { useEffect, useState } from 'react';
 
@@ -12,12 +14,15 @@ interface ProfessionsSvgProps {
   persons: Array<Person>;
   parentRef: MutableRefObject<HTMLDivElement | null>;
   renderLabel: boolean;
-  hovered?: Person['occupation'] | null;
-  setHovered?: (val: Person['occupation'] | null) => void;
+  hovered?: Person['id'] | null;
+  setHovered?: (val: Array<Person['id']> | null) => void;
 }
 
 const svgMinWidth = 300;
 const svgMinHeight = 150;
+
+const noOccupation = Symbol('no occupation');
+export type NoOccupation = typeof noOccupation;
 
 export function ProfessionsSvg(props: ProfessionsSvgProps): JSX.Element {
   const { parentRef, persons, renderLabel, hovered, setHovered } = props;
@@ -25,7 +30,13 @@ export function ProfessionsSvg(props: ProfessionsSvgProps): JSX.Element {
   const [svgWidth, setSvgWidth] = useState(svgMinWidth);
   const [svgHeight, setSvgHeight] = useState(svgMinHeight);
 
-  const _placateEslint = { parentRef, persons, renderLabel, hovered, setHovered };
+  const x = createHierarchy(persons);
+  console.log(x.descendants().slice(1));
+
+  const xScale = scaleLinear().range([20, 300]);
+  const yScale = scaleLinear().range([20, 300]);
+
+  const _placateEslint = { parentRef, persons, renderLabel, hovered, setHovered };  // XXX
 
   useEffect(() => {
     const w = Math.max(svgMinWidth, parentRef.current?.clientWidth ?? 0);
@@ -58,6 +69,19 @@ export function ProfessionsSvg(props: ProfessionsSvgProps): JSX.Element {
       style={{ minWidth: `${svgMinWidth}px`, minHeight: `${svgMinHeight}px` }}
       viewBox={svgViewBox}
     >
+      {x.descendants().slice(1).map((node) => {
+        return (
+          <g key={node.data.label}>
+            <rect x={xScale(node.y0)}
+                  y={yScale(node.x0)}
+                  width={xScale(node.y1) - xScale(node.y0)}
+                  height={yScale(node.x1) - yScale(node.x0)}
+                  fill="red" />
+            <text x={xScale(node.y0) + 2}
+                  y={yScale(node.x0) + 10}>{node.data.label}</text>
+          </g>
+        );
+      })}
       {/**
       <TimelineYearAxis xScale={scaleX} yScale={scaleY} />
       {persons.map((person) => {
@@ -72,4 +96,80 @@ export function ProfessionsSvg(props: ProfessionsSvgProps): JSX.Element {
       */}
     </svg>
   );
+}
+
+function createHierarchy(persons: Array<Person>) {
+  const alphabeticalGroups = [
+    ['A-I', /^[a-i]/i],
+    ['J-P', /^[j-p]/i],
+    ['Q-Z', /^[q-z]/i],
+    ['other', /^./i],  // rest
+  ];
+
+  const flattened: Array<[typeof alphabeticalGroups[0][0], string | NoOccupation, Person['id']]> = [];
+  persons.forEach(person => {
+    if (person.occupation === undefined) {
+      const alphabeticalGroup = alphabeticalGroups[0][0];
+      flattened.push([alphabeticalGroup, noOccupation, person.id]);
+
+      return;
+    }
+
+    person.occupation.forEach((occupation) => {
+      const alphabeticalGroup = alphabeticalGroups
+        .find(([_, regex]) => {
+          return regex.test(occupation);
+        })
+        [0] ?? alphabeticalGroups[alphabeticalGroups.length - 1][0];
+
+      flattened.push([alphabeticalGroup, occupation, person.id]);
+    });
+  });
+
+  const groupedByProfession = group(flattened,
+    d => d[0],
+    d => d[1],
+  );
+
+
+  console.log(groupedByProfession);
+
+  const root = {
+    label: 'all',
+    personIds: persons.map(d => d.id),
+    children: unifyTree(groupedByProfession),
+  };
+  const hier = hierarchy(root)
+    .sum(d => d.children ? 0 : d.personIds.length)
+    .sort((a, b) => a.data.label.localeCompare(b.data.label));
+
+  const part = partition()
+    .padding(0.005)
+    (hier);
+
+  return part;
+}
+
+function unifyTree(groupNode) {
+  const entries = Array.from(groupNode.entries());
+  if (entries[0][1] instanceof Array) {
+    // lowest level
+    return entries.map(([key, value]) => {
+      return {
+        label: key,
+        personIds: value.map(d => d[2]),
+      };
+    });
+  } else {
+    // entries' values are also maps
+    return entries.map(([key, value]) => {
+      const children = unifyTree(value);
+      const personIds = Array.from(new Set<string>(children.map(d => d.personIds).flat()));
+      return {
+        label: key,
+        personIds,
+        children,
+      };
+    });
+  }
 }

--- a/src/features/professions/professions-svg.tsx
+++ b/src/features/professions/professions-svg.tsx
@@ -1,23 +1,28 @@
-import { scaleLinear, scaleOrdinal } from 'd3-scale';
-import { schemeRdYlGn, interpolateCool, interpolateWarm } from 'd3-scale-chromatic';
-import { color as d3color, hsl } from 'd3-color';
-import { hierarchy, partition } from 'd3-hierarchy';
-import type { HierarchyNode } from 'd3-hierarchy';
+import type { InternMap } from 'd3-array';
 import { extent, group } from 'd3-array';
+import type { HSLColor } from 'd3-color';
+import { hsl } from 'd3-color';
+import type { HierarchyRectangularNode } from 'd3-hierarchy';
+import { hierarchy, partition } from 'd3-hierarchy';
+import { scaleLinear } from 'd3-scale';
+import { interpolateCool } from 'd3-scale-chromatic';
 import type { MutableRefObject } from 'react';
 import { useEffect, useState } from 'react';
 
 import type { Person } from '@/features/common/entity.model';
 import { ProfessionHierarchyNode } from '@/features/professions/profession-hierarchy-node';
 
-type LeafSizing = 'qualitative' | 'quantitative';
+export enum LeafSizing {
+  Qualitative,
+  Quantitative,
+}
 
 interface ProfessionsSvgProps {
   persons: Array<Person>;
   parentRef: MutableRefObject<HTMLDivElement | null>;
   renderLabel: boolean;
   leafSizing?: LeafSizing;
-  hovered?: Person['id'] | null;
+  hovered?: Array<Person['id']> | null;
   setHovered?: (val: Array<Person['id']> | null) => void;
 }
 
@@ -32,18 +37,28 @@ export function ProfessionsSvg(props: ProfessionsSvgProps): JSX.Element {
     parentRef,
     persons,
     renderLabel,
-    hovered, setHovered,
-    leafSizing = 'quantitative',
+    hovered,
+    setHovered,
+    leafSizing = LeafSizing.Quantitative,
   } = props;
+
   const [svgViewBox, setSvgViewBox] = useState(`0 0 ${svgMinWidth} ${svgMinHeight}`);
   const [svgWidth, setSvgWidth] = useState(svgMinWidth);
   const [svgHeight, setSvgHeight] = useState(svgMinHeight);
 
   const hierarchyRoot = createHierarchy(persons, leafSizing);
-  const allButRootNode = hierarchyRoot.descendants().filter(d => d.depth > 0);
+  const allButRootNode = hierarchyRoot.descendants().filter((d) => {
+    return d.depth > 0;
+  });
 
   // x is y, y is x
-  const dataXRange: [number, number] = extent<number>(allButRootNode.map(d => [d.y0, d.y1]).flat());
+  const dataXRange: [number, number] = extent<number>(
+    allButRootNode
+      .map((d) => {
+        return [d.y0, d.y1];
+      })
+      .flat(),
+  ) as [number, number];
 
   const xScale = scaleLinear()
     .domain(dataXRange)
@@ -51,12 +66,12 @@ export function ProfessionsSvg(props: ProfessionsSvgProps): JSX.Element {
   const yScale = scaleLinear().range([20, svgHeight - 20]);
 
   // store colors per node in a map
-  const colorMap = new Map<string, string>();
+  const colorMap = new Map<NoOccupation | string, string>();
 
-  hierarchyRoot.children.forEach((child, i, arr) => {
+  hierarchyRoot.children?.forEach((child, i, arr) => {
     const idx = i / (arr.length - 1);
     const col1 = interpolateCool(idx);
-    const hsl1 = hsl(d3color(col1));
+    const hsl1 = hsl(col1);
 
     // root color: mostly saturated
     const rootColor = hsl(hsl1.h, 0.8, 0.4);
@@ -64,17 +79,21 @@ export function ProfessionsSvg(props: ProfessionsSvgProps): JSX.Element {
 
     const childColor1 = hsl(hsl1.h, 0.5, 0.5);
     const childColor2 = hsl(hsl1.h, 0.5, 0.75);
-    const childColorScale = scaleLinear()
-      .domain([0, Math.max(4, child.children.length - 1)])
+    const childColorScale = scaleLinear<HSLColor>()
+      .domain([0, Math.max(4, (child.children?.length ?? 0) - 1)])
       .range([childColor1, childColor2]);
 
-    child.children.forEach((child, i) => {
+    child.children?.forEach((child, i) => {
       const color = childColorScale(i);
-      colorMap.set(child.data.label, color);
+      colorMap.set(child.data.label, color.toString());
 
       // XXX: assume two levels of hierarchy for now, rest is same color
-      const grandchildren = child.descendants().filter(d => d.depth !== child.depth);
-      grandchildren.forEach(grandchild => colorMap.set(grandchild.data.label, color));
+      const grandchildren = child.descendants().filter((d) => {
+        return d.depth !== child.depth;
+      });
+      grandchildren.forEach((grandchild) => {
+        return colorMap.set(grandchild.data.label, color.toString());
+      });
     });
   });
 
@@ -96,9 +115,11 @@ export function ProfessionsSvg(props: ProfessionsSvgProps): JSX.Element {
       viewBox={svgViewBox}
     >
       {allButRootNode.map((node) => {
+        const label = node.data.label === noOccupation ? 'no occupation' : node.data.label;
+
         return (
           <ProfessionHierarchyNode
-            key={node.data.label}
+            key={label}
             x0={node.y0}
             x1={node.y1}
             y0={node.x0}
@@ -109,81 +130,129 @@ export function ProfessionsSvg(props: ProfessionsSvgProps): JSX.Element {
             renderLabel={renderLabel}
             hovered={hovered}
             setHovered={setHovered}
-            label={node.data.label}
-            color={colorMap.get(node.data.label) ?? 'hotpink'} />
+            label={label}
+            color={colorMap.get(node.data.label) ?? 'hotpink'}
+          />
         );
       })}
     </svg>
   );
 }
 
-function createHierarchy(persons: Array<Person>, leafSizing: LeafSizing) {
-  const alphabeticalGroups = [
-    ['A-I', /^[a-i]/i],
-    ['J-P', /^[j-p]/i],
-    ['Q-Z', /^[q-z]/i],
-    ['other', /^./i],  // rest
-  ];
+// XXX use alphabetical groups for now, with the mock data
+const alphabeticalGroups: Array<[string, RegExp]> = [
+  ['A-I', /^[a-i]/i],
+  ['J-P', /^[j-p]/i],
+  ['Q-Z', /^[q-z]/i],
+  ['other', /^./i], // rest
+];
 
-  const flattened: Array<[typeof alphabeticalGroups[0][0], string | NoOccupation, Person['id']]> = [];
-  persons.forEach(person => {
-    if (person.occupation === undefined) {
-      const alphabeticalGroup = alphabeticalGroups[0][0];
-      flattened.push([alphabeticalGroup, noOccupation, person.id]);
+type OccupationEntryTriple = [typeof alphabeticalGroups[0][0], NoOccupation | string, Person['id']];
+interface OccupationTreeEntry {
+  label: NoOccupation | string;
+  personIds: Array<Person['id']>;
+  children?: Array<OccupationTreeEntry>;
+}
+type ProfessionGroupingResult =
+  | Array<OccupationEntryTriple>
+  | InternMap<OccupationTreeEntry['label'], ProfessionGroupingResult>;
+type ParentProfessionGroupingResult = InternMap<
+  OccupationTreeEntry['label'],
+  ProfessionGroupingResult
+>;
+
+function createHierarchy(
+  persons: Array<Person>,
+  leafSizing: LeafSizing,
+): HierarchyRectangularNode<OccupationTreeEntry> {
+  const flattened: Array<OccupationEntryTriple> = [];
+  persons.forEach((person) => {
+    if (person.occupation.length === 0) {
+      flattened.push(['other', noOccupation, person.id]);
 
       return;
     }
 
     person.occupation.forEach((occupation) => {
-      const alphabeticalGroup = alphabeticalGroups
-        .find(([_, regex]) => {
-          return regex.test(occupation);
-        })
-        [0] ?? alphabeticalGroups[alphabeticalGroups.length - 1][0];
+      const [alphabeticalGroup, _] = alphabeticalGroups.find(([_, regex]) => {
+        return regex.test(occupation);
+      }) ?? ['other', null];
 
       flattened.push([alphabeticalGroup, occupation, person.id]);
     });
   });
 
-  const groupedByProfession = group(flattened,
-    d => d[0],
-    d => d[1],
+  const groupedByProfession = group(
+    flattened,
+    (d) => {
+      return d[0];
+    },
+    (d) => {
+      return d[1];
+    },
   );
 
-  const root = {
+  const root: OccupationTreeEntry = {
     label: 'all',
-    personIds: persons.map(d => d.id),
+    personIds: persons.map((d) => {
+      return d.id;
+    }),
     children: unifyTree(groupedByProfession),
   };
 
-  const leafSizeFn = (leafSizing === 'quantitative')
-    ? (node: HierarchyNode<typeof root>): number => node.children ? 0 : node.personIds.length
-    : (node: HierarchyNode<typeof root>): number => node.children ? 0 : 1;
+  const leafSizeFn =
+    leafSizing === LeafSizing.Quantitative
+      ? (node: OccupationTreeEntry): number => {
+          return node.children ? 0 : node.personIds.length;
+        }
+      : (node: OccupationTreeEntry): number => {
+          return node.children ? 0 : 1;
+        };
 
-  const hier = hierarchy(root)
+  const hier = hierarchy<OccupationTreeEntry>(root)
     .sum(leafSizeFn)
-    .sort((a, b) => a.data.label.localeCompare(b.data.label));
+    .sort((a, b) => {
+      // no occupation: first
+      if (a.data.label === noOccupation) return -1;
+      if (b.data.label === noOccupation) return 1;
 
-  const part = partition()(hier);
+      return a.data.label.localeCompare(b.data.label);
+    });
+
+  const part = partition<OccupationTreeEntry>()(hier);
 
   return part;
 }
 
-function unifyTree(groupNode) {
+/**
+ * Take the result of a multi-level `d3.group`, and return an object that can
+ * be fed into `d3.hierarchy`.
+ */
+function unifyTree(groupNode: ParentProfessionGroupingResult): Array<OccupationTreeEntry> {
   const entries = Array.from(groupNode.entries());
-  if (entries[0][1] instanceof Array) {
+  if (entries.at(0)?.at(1) instanceof Array) {
     // lowest level
     return entries.map(([key, value]) => {
       return {
         label: key,
-        personIds: value.map(d => d[2]),
+        personIds: (value as Array<OccupationEntryTriple>).map((d) => {
+          return d[2];
+        }),
       };
     });
   } else {
     // entries' values are also maps
     return entries.map(([key, value]) => {
-      const children = unifyTree(value);
-      const personIds = Array.from(new Set<string>(children.map(d => d.personIds).flat()));
+      const children = unifyTree(value as ParentProfessionGroupingResult);
+      const personIds = Array.from(
+        new Set<string>(
+          children
+            .map((d) => {
+              return d.personIds;
+            })
+            .flat(),
+        ),
+      );
       return {
         label: key,
         personIds,

--- a/src/features/professions/professions-svg.tsx
+++ b/src/features/professions/professions-svg.tsx
@@ -1,0 +1,75 @@
+//import { extent } from 'd3-array';
+//import { scaleBand, scaleTime } from 'd3-scale';
+import type { MutableRefObject } from 'react';
+import { useEffect, useState } from 'react';
+
+import type { Person } from '@/features/common/entity.model';
+//import { TimelineElement } from '@/features/timeline/timeline-element';
+//import { TimelineElementTooltip } from '@/features/timeline/timeline-element-tooltip';
+//import { TimelineYearAxis } from '@/features/timeline/timeline-year-axis';
+
+interface ProfessionsSvgProps {
+  persons: Array<Person>;
+  parentRef: MutableRefObject<HTMLDivElement | null>;
+  renderLabel: boolean;
+  hovered?: Person['occupation'] | null;
+  setHovered?: (val: Person['occupation'] | null) => void;
+}
+
+const svgMinWidth = 300;
+const svgMinHeight = 150;
+
+export function ProfessionsSvg(props: ProfessionsSvgProps): JSX.Element {
+  const { parentRef, persons, renderLabel, hovered, setHovered } = props;
+  const [svgViewBox, setSvgViewBox] = useState(`0 0 ${svgMinWidth} ${svgMinHeight}`);
+  const [svgWidth, setSvgWidth] = useState(svgMinWidth);
+  const [svgHeight, setSvgHeight] = useState(svgMinHeight);
+
+  const _placateEslint = { parentRef, persons, renderLabel, hovered, setHovered };
+
+  useEffect(() => {
+    const w = Math.max(svgMinWidth, parentRef.current?.clientWidth ?? 0);
+    const h = Math.max(svgMinHeight, parentRef.current?.clientHeight ?? 0);
+
+    setSvgWidth(w);
+    setSvgHeight(h);
+    setSvgViewBox(`0 0 ${w} ${h}`);
+  }, [parentRef]);
+
+  //const timeDomain = zoomToData ? getTemporalExtent(persons) : getTemporalExtent([]);
+  //
+  //const scaleX = scaleTime()
+  //  .domain(timeDomain)
+  //  .range([50, svgWidth - 50]);
+  //const scaleY = scaleBand()
+  //  .domain(
+  //    persons.map((d) => {
+  //      return d.id;
+  //    }),
+  //  )
+  //  .range([50, svgHeight - 80])
+  //  .paddingInner(0.2);
+
+  return (
+    <svg
+      id="professions"
+      width={svgWidth}
+      height={svgHeight}
+      style={{ minWidth: `${svgMinWidth}px`, minHeight: `${svgMinHeight}px` }}
+      viewBox={svgViewBox}
+    >
+      {/**
+      <TimelineYearAxis xScale={scaleX} yScale={scaleY} />
+      {persons.map((person) => {
+        const personProps = { scaleX, scaleY, person, renderLabel, hovered, setHovered };
+
+        return (
+          <TimelineElementTooltip key={person.id} {...personProps}>
+            <TimelineElement key={person.id} {...personProps} />
+          </TimelineElementTooltip>
+        );
+      })}
+      */}
+    </svg>
+  );
+}

--- a/src/features/professions/professions-svg.tsx
+++ b/src/features/professions/professions-svg.tsx
@@ -13,9 +13,26 @@ import type { ToggleProfessionFn } from '@/features/professions/professions';
 import { Origin } from '@/features/visual-querying/Origin';
 import type { ProfessionConstraint } from '@/features/visual-querying/visualQuerying.slice';
 
+/**
+ * Determines how the tree is split up into its leaves size-wise.
+ */
 export enum LeafSizing {
+  /**
+   * All leaf nodes have the same height. Parent nodes have the height of the
+   * sum of their children.
+   */
   Qualitative,
+  /**
+   * Same sizing as above, but the leaf nodes also contain a bar encoding the
+   * leaf's value. Bar scaling is consistent across all leaves. This is used,
+   * for example, in the visual querying profession constraint, where all
+   * leaves (even those with value 0) should be visible, but the number of
+   * persons with that profession should still be gleanable (scented widget).
+   */
   QualitativeWithBar,
+  /**
+   * Leaf node height is determined by the node's value.
+   */
   Quantitative,
 }
 
@@ -147,6 +164,12 @@ export function ProfessionsSvg(props: ProfessionsSvgProps): JSX.Element {
 
 type _HierarchyData = Profession & { count: number };
 
+/**
+ * Convert the list of { name, parent, count } tuples to a d3 hierarchy,
+ * respecting the chosen leaf sizing. A dummy root element is added as there
+ * might be multiple elements with no parent (subtree roots). This global root
+ * is later cut away before visualizing the tree.
+ */
 function createHierarchy(
   professions: Array<_HierarchyData>,
   leafSizing: LeafSizing,

--- a/src/features/professions/professions-svg.tsx
+++ b/src/features/professions/professions-svg.tsx
@@ -42,7 +42,7 @@ export function ProfessionsSvg(props: ProfessionsSvgProps): JSX.Element {
 
   // store colors per node in a map
   const colorMap = new Map<string, string>();
-  // XXX: assume two levels of hierarchy for now
+
   hierarchyRoot.children.forEach((child, i, arr) => {
     const idx = i / (arr.length - 1);
     const col1 = interpolateCool(idx);
@@ -61,6 +61,10 @@ export function ProfessionsSvg(props: ProfessionsSvgProps): JSX.Element {
     child.children.forEach((child, i) => {
       const color = childColorScale(i);
       colorMap.set(child.data.label, color);
+
+      // XXX: assume two levels of hierarchy for now, rest is same color
+      const grandchildren = child.descendants().filter(d => d.depth !== child.depth);
+      grandchildren.forEach(grandchild => colorMap.set(grandchild.data.label, color));
     });
   });
 
@@ -141,6 +145,7 @@ function createHierarchy(persons: Array<Person>) {
     personIds: persons.map(d => d.id),
     children: unifyTree(groupedByProfession),
   };
+
   const hier = hierarchy(root)
     .sum(d => d.children ? 0 : d.personIds.length)
     .sort((a, b) => a.data.label.localeCompare(b.data.label));

--- a/src/features/professions/professions-svg.tsx
+++ b/src/features/professions/professions-svg.tsx
@@ -11,6 +11,8 @@ import { useEffect, useState } from 'react';
 
 import type { Person } from '@/features/common/entity.model';
 import { ProfessionHierarchyNode } from '@/features/professions/profession-hierarchy-node';
+import type { ProfessionConstraint } from '@/features/visual-querying/visualQuerying.slice';
+import type { ToggleProfessionFn } from '@/features/professions/professions.tsx';
 
 export enum LeafSizing {
   Qualitative,
@@ -24,6 +26,8 @@ interface ProfessionsSvgProps {
   leafSizing?: LeafSizing;
   hovered?: Array<Person['id']> | null;
   setHovered?: (val: Array<Person['id']> | null) => void;
+  constraint?: ProfessionConstraint;
+  toggleProfession: ToggleProfessionFn;
 }
 
 const svgMinWidth = 300;
@@ -40,6 +44,8 @@ export function ProfessionsSvg(props: ProfessionsSvgProps): JSX.Element {
     hovered,
     setHovered,
     leafSizing = LeafSizing.Quantitative,
+    constraint,
+    toggleProfession,
   } = props;
 
   const [svgViewBox, setSvgViewBox] = useState(`0 0 ${svgMinWidth} ${svgMinHeight}`);
@@ -116,6 +122,9 @@ export function ProfessionsSvg(props: ProfessionsSvgProps): JSX.Element {
     >
       {allButRootNode.map((node) => {
         const label = node.data.label === noOccupation ? 'no occupation' : node.data.label;
+        const professionIds = node.data.label === noOccupation
+          ? []
+          : node.descendants().filter(d => (d.children?.length ?? 0) === 0).map(d => d.data.label);
 
         return (
           <ProfessionHierarchyNode
@@ -125,6 +134,7 @@ export function ProfessionsSvg(props: ProfessionsSvgProps): JSX.Element {
             y0={node.x0}
             y1={node.x1}
             personIds={node.data.personIds}
+            professionIds={professionIds}
             scaleX={xScale}
             scaleY={yScale}
             renderLabel={renderLabel}
@@ -132,6 +142,10 @@ export function ProfessionsSvg(props: ProfessionsSvgProps): JSX.Element {
             setHovered={setHovered}
             label={label}
             color={colorMap.get(node.data.label) ?? 'hotpink'}
+
+            selectable={!!constraint}
+            selected={constraint?.selection?.has(node.data.label) ?? false}
+            toggleProfession={toggleProfession}
           />
         );
       })}

--- a/src/features/professions/professions.module.css
+++ b/src/features/professions/professions.module.css
@@ -1,4 +1,3 @@
 .professions-wrapper {
-  min-height: 50vh;
   display: grid;
 }

--- a/src/features/professions/professions.module.css
+++ b/src/features/professions/professions.module.css
@@ -1,0 +1,4 @@
+.professions-wrapper {
+  min-height: 50vh;
+  display: grid;
+}

--- a/src/features/professions/professions.tsx
+++ b/src/features/professions/professions.tsx
@@ -1,7 +1,7 @@
 import { useRef } from 'react';
 
-import { useAppDispatch, useAppSelector } from '@/app/store';
-import { selectEntitiesByKind } from '@/features/common/entities.slice';
+import { useAppDispatch } from '@/app/store';
+import type { Profession as ProfessionEntity } from '@/features/common/entity.model';
 import styles from '@/features/professions/professions.module.css';
 import type { LeafSizing } from '@/features/professions/professions-svg';
 import { ProfessionsSvg } from '@/features/professions/professions-svg';
@@ -13,6 +13,7 @@ import type {
 import { updateProfessions } from '@/features/visual-querying/visualQuerying.slice';
 
 interface ProfessionsProps {
+  professions: Array<ProfessionEntity & { count: number }>;
   origin: Origin;
   leafSizing: LeafSizing;
   constraint?: ProfessionConstraint;
@@ -20,11 +21,13 @@ interface ProfessionsProps {
 
 export type ToggleProfessionFn = (professions: Array<Profession>) => void;
 
-export function Professions({ constraint, leafSizing, origin }: ProfessionsProps): JSX.Element {
+export function Professions({
+  constraint,
+  leafSizing,
+  origin,
+  professions,
+}: ProfessionsProps): JSX.Element {
   const dispatch = useAppDispatch();
-
-  const entities = useAppSelector(selectEntitiesByKind);
-  const persons = Object.values(entities.person).slice(0 /*10*/); // XXX
 
   const parent = useRef<HTMLDivElement>(null);
 
@@ -60,7 +63,7 @@ export function Professions({ constraint, leafSizing, origin }: ProfessionsProps
     <div className={styles['professions-wrapper']} ref={parent}>
       <ProfessionsSvg
         parentRef={parent}
-        persons={persons}
+        professions={professions}
         renderLabel={true}
         leafSizing={leafSizing}
         constraint={constraint}

--- a/src/features/professions/professions.tsx
+++ b/src/features/professions/professions.tsx
@@ -1,0 +1,19 @@
+import { useRef } from 'react';
+
+import { useAppSelector } from '@/app/store';
+import { selectEntitiesByKind } from '@/features/common/entities.slice';
+import styles from '@/features/professions/professions.module.css';
+import { ProfessionsSvg } from '@/features/professions/professions-svg';
+
+export function Professions(): JSX.Element {
+  const entities = useAppSelector(selectEntitiesByKind);
+  const persons = Object.values(entities.person).slice(0 /*10*/); // XXX
+
+  const parent = useRef<HTMLDivElement>(null);
+
+  return (
+    <div className={styles['professions-wrapper']} ref={parent}>
+      <ProfessionsSvg parentRef={parent} persons={persons} renderLabel={true} />
+    </div>
+  );
+}

--- a/src/features/professions/professions.tsx
+++ b/src/features/professions/professions.tsx
@@ -1,15 +1,35 @@
 import { useRef } from 'react';
 
-import { useAppSelector } from '@/app/store';
+import { useAppSelector, useAppDispatch } from '@/app/store';
 import { selectEntitiesByKind } from '@/features/common/entities.slice';
 import styles from '@/features/professions/professions.module.css';
 import { LeafSizing, ProfessionsSvg } from '@/features/professions/professions-svg';
+import type { ProfessionConstraint } from '@/features/visual-querying/visualQuerying.slice';
+import { updateProfessions } from '@/features/visual-querying/visualQuerying.slice';
 
-export function Professions(): JSX.Element {
+interface ProfessionsProps {
+  constraint?: ProfessionConstraint;
+};
+
+export type ToggleProfessionFn = (
+  (
+    profession: Iterable<Parameters<ProfessionConstraint['selection']['has']>[0]>,
+    contained: boolean
+  ) => void
+);
+
+export function Professions({ constraint }: ProfessionsProps): JSX.Element {
+  const dispatch = useAppDispatch();
+
   const entities = useAppSelector(selectEntitiesByKind);
   const persons = Object.values(entities.person).slice(0 /*10*/); // XXX
 
   const parent = useRef<HTMLDivElement>(null);
+
+  function toggleProfession(profession: Parameters<ToggleProfessionFn>[0], contained: Parameters<ToggleProfessionFn>[1]) {
+    console.log('toggle', profession);
+    // TODO
+  }
 
   return (
     <div className={styles['professions-wrapper']} ref={parent}>
@@ -18,6 +38,8 @@ export function Professions(): JSX.Element {
         persons={persons}
         renderLabel={true}
         leafSizing={LeafSizing.Qualitative}
+        constraint={constraint}
+        toggleProfession={toggleProfession}
       />
     </div>
   );

--- a/src/features/professions/professions.tsx
+++ b/src/features/professions/professions.tsx
@@ -13,7 +13,7 @@ export function Professions(): JSX.Element {
 
   return (
     <div className={styles['professions-wrapper']} ref={parent}>
-      <ProfessionsSvg parentRef={parent} persons={persons} renderLabel={true} />
+      <ProfessionsSvg parentRef={parent} persons={persons} renderLabel={true} leafSizing={'qualitative'} />
     </div>
   );
 }

--- a/src/features/professions/professions.tsx
+++ b/src/features/professions/professions.tsx
@@ -3,7 +3,8 @@ import { useRef } from 'react';
 import { useAppDispatch, useAppSelector } from '@/app/store';
 import { selectEntitiesByKind } from '@/features/common/entities.slice';
 import styles from '@/features/professions/professions.module.css';
-import { LeafSizing, ProfessionsSvg } from '@/features/professions/professions-svg';
+import type { LeafSizing } from '@/features/professions/professions-svg';
+import { ProfessionsSvg } from '@/features/professions/professions-svg';
 import type { Origin } from '@/features/visual-querying/Origin';
 import type {
   Profession,
@@ -13,12 +14,13 @@ import { updateProfessions } from '@/features/visual-querying/visualQuerying.sli
 
 interface ProfessionsProps {
   origin: Origin;
+  leafSizing: LeafSizing;
   constraint?: ProfessionConstraint;
 }
 
 export type ToggleProfessionFn = (professions: Array<Profession>) => void;
 
-export function Professions({ constraint, origin }: ProfessionsProps): JSX.Element {
+export function Professions({ constraint, leafSizing, origin }: ProfessionsProps): JSX.Element {
   const dispatch = useAppDispatch();
 
   const entities = useAppSelector(selectEntitiesByKind);
@@ -60,7 +62,7 @@ export function Professions({ constraint, origin }: ProfessionsProps): JSX.Eleme
         parentRef={parent}
         persons={persons}
         renderLabel={true}
-        leafSizing={LeafSizing.Qualitative}
+        leafSizing={leafSizing}
         constraint={constraint}
         toggleProfession={toggleProfession}
         origin={origin}

--- a/src/features/professions/professions.tsx
+++ b/src/features/professions/professions.tsx
@@ -3,17 +3,22 @@ import { useRef } from 'react';
 import { useAppSelector } from '@/app/store';
 import { selectEntitiesByKind } from '@/features/common/entities.slice';
 import styles from '@/features/professions/professions.module.css';
-import { ProfessionsSvg } from '@/features/professions/professions-svg';
+import { LeafSizing, ProfessionsSvg } from '@/features/professions/professions-svg';
 
 export function Professions(): JSX.Element {
   const entities = useAppSelector(selectEntitiesByKind);
-  const persons = Object.values(entities.person).slice(0, /*10*/); // XXX
+  const persons = Object.values(entities.person).slice(0 /*10*/); // XXX
 
   const parent = useRef<HTMLDivElement>(null);
 
   return (
     <div className={styles['professions-wrapper']} ref={parent}>
-      <ProfessionsSvg parentRef={parent} persons={persons} renderLabel={true} leafSizing={'qualitative'} />
+      <ProfessionsSvg
+        parentRef={parent}
+        persons={persons}
+        renderLabel={true}
+        leafSizing={LeafSizing.Qualitative}
+      />
     </div>
   );
 }

--- a/src/features/professions/professions.tsx
+++ b/src/features/professions/professions.tsx
@@ -4,6 +4,7 @@ import { useAppDispatch, useAppSelector } from '@/app/store';
 import { selectEntitiesByKind } from '@/features/common/entities.slice';
 import styles from '@/features/professions/professions.module.css';
 import { LeafSizing, ProfessionsSvg } from '@/features/professions/professions-svg';
+import type { Origin } from '@/features/visual-querying/Origin';
 import type {
   Profession,
   ProfessionConstraint,
@@ -11,12 +12,13 @@ import type {
 import { updateProfessions } from '@/features/visual-querying/visualQuerying.slice';
 
 interface ProfessionsProps {
+  origin: Origin;
   constraint?: ProfessionConstraint;
 }
 
 export type ToggleProfessionFn = (professions: Array<Profession>) => void;
 
-export function Professions({ constraint }: ProfessionsProps): JSX.Element {
+export function Professions({ constraint, origin }: ProfessionsProps): JSX.Element {
   const dispatch = useAppDispatch();
 
   const entities = useAppSelector(selectEntitiesByKind);
@@ -61,6 +63,7 @@ export function Professions({ constraint }: ProfessionsProps): JSX.Element {
         leafSizing={LeafSizing.Qualitative}
         constraint={constraint}
         toggleProfession={toggleProfession}
+        origin={origin}
       />
     </div>
   );

--- a/src/features/professions/professions.tsx
+++ b/src/features/professions/professions.tsx
@@ -7,7 +7,7 @@ import { ProfessionsSvg } from '@/features/professions/professions-svg';
 
 export function Professions(): JSX.Element {
   const entities = useAppSelector(selectEntitiesByKind);
-  const persons = Object.values(entities.person).slice(0 /*10*/); // XXX
+  const persons = Object.values(entities.person).slice(0, /*10*/); // XXX
 
   const parent = useRef<HTMLDivElement>(null);
 

--- a/src/features/professions/professions.tsx
+++ b/src/features/professions/professions.tsx
@@ -31,8 +31,15 @@ export function Professions({
 
   const parent = useRef<HTMLDivElement>(null);
 
+  /**
+   * Toggle professions on or off in the constraint. If the profession is a
+   * subtree parent, only the leaves are toggled. Here, the inverse of the
+   * majority value will be the new value for all nodes (i.e., if more than 50%
+   * of nodes are deselected previously, all will be selected, and vice versa).
+   */
   function toggleProfession(professions: Parameters<ToggleProfessionFn>[0]) {
     if (!constraint) return;
+
     const numContained = professions
       .map((d) => {
         return constraint.selection?.includes(d);

--- a/src/features/visual-querying/PersonShape.tsx
+++ b/src/features/visual-querying/PersonShape.tsx
@@ -4,10 +4,13 @@ import { useAppSelector } from '@/app/store';
 import { ConstraintList } from '@/features/visual-querying/ConstraintList';
 import { DateConstraintView } from '@/features/visual-querying/DateConstraintView';
 import type { Origin } from '@/features/visual-querying/Origin';
+import { ProfessionConstraintView } from '@/features/visual-querying/ProfessionConstraintView';
 import { RingConstraint } from '@/features/visual-querying/RingConstraint';
 import { TextConstraintView } from '@/features/visual-querying/TextConstraintView';
 import type {
   DateConstraint,
+  Profession,
+  ProfessionConstraint,
   TextConstraint,
 } from '@/features/visual-querying/visualQuerying.slice';
 import { ConstraintType, selectConstraints } from '@/features/visual-querying/visualQuerying.slice';
@@ -70,7 +73,25 @@ export function PersonShape(props: PersonShapeProps): JSX.Element {
             const dateRange = (constraint as DateConstraint).dateRange;
             valueDescription = dateRange ? dateRange.toString() : null;
             break;
+          case ConstraintType.Profession: {
+            // <-- lexical scope to appease esline no-case-declarations
+            const selection = (constraint as ProfessionConstraint).selection;
+            if (!selection) break; // empty
+
+            if (selection.length <= 3) {
+              valueDescription = selection.join(', ');
+              break;
+            }
+
+            const [first, second, ...rest] = selection as Array<Profession>;
+            valueDescription = `${first}, ${second}, ... (${rest.length} more)`;
+            break;
+          }
           default:
+            console.warn(
+              'No constraint ring description defined for constraint type:',
+              constraint.type,
+            );
             valueDescription = null;
             break;
         }
@@ -137,6 +158,18 @@ export function PersonShape(props: PersonShapeProps): JSX.Element {
             //       height={350}
             //     />
             //   );
+            case ConstraintType.Profession:
+              return (
+                <ProfessionConstraintView
+                  key={idx}
+                  idx={idx}
+                  constraint={constraint as ProfessionConstraint}
+                  x={x}
+                  y={y}
+                  width={300}
+                  height={400}
+                />
+              );
             default:
               return (
                 <text x={x} y={y} fill="red">

--- a/src/features/visual-querying/PersonShape.tsx
+++ b/src/features/visual-querying/PersonShape.tsx
@@ -168,6 +168,7 @@ export function PersonShape(props: PersonShapeProps): JSX.Element {
                   y={y}
                   width={300}
                   height={400}
+                  origin={origin.clone()}
                 />
               );
             default:

--- a/src/features/visual-querying/ProfessionConstraintView.tsx
+++ b/src/features/visual-querying/ProfessionConstraintView.tsx
@@ -1,0 +1,33 @@
+import { Paper } from '@mui/material';
+
+import { Professions } from '@/features/professions/professions';
+import type { ProfessionConstraint } from '@/features/visual-querying/visualQuerying.slice';
+
+interface ProfessionConstraintProps {
+  idx: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  constraint: ProfessionConstraint;
+}
+
+export function ProfessionConstraintView(props: ProfessionConstraintProps): JSX.Element {
+  const { x, y, width, height, constraint } = props;
+
+  return (
+    <foreignObject x={x} y={y} width={width} height={height}>
+      <Paper
+        elevation={3}
+        sx={{
+          margin: '2px',
+          width: width - 4,
+          height: height - 4,
+          display: 'grid',
+        }}
+      >
+        <Professions constraint={constraint} />
+      </Paper>
+    </foreignObject>
+  );
+}

--- a/src/features/visual-querying/ProfessionConstraintView.tsx
+++ b/src/features/visual-querying/ProfessionConstraintView.tsx
@@ -1,6 +1,7 @@
 import { Paper } from '@mui/material';
 
 import { Professions } from '@/features/professions/professions';
+import { LeafSizing } from '@/features/professions/professions-svg';
 import { Origin } from '@/features/visual-querying/Origin';
 import type { ProfessionConstraint } from '@/features/visual-querying/visualQuerying.slice';
 
@@ -31,7 +32,11 @@ export function ProfessionConstraintView(props: ProfessionConstraintProps): JSX.
           display: 'grid',
         }}
       >
-        <Professions constraint={constraint} origin={origin} />
+        <Professions
+          constraint={constraint}
+          origin={origin}
+          leafSizing={LeafSizing.QualitativeWithBar}
+        />
       </Paper>
     </foreignObject>
   );

--- a/src/features/visual-querying/ProfessionConstraintView.tsx
+++ b/src/features/visual-querying/ProfessionConstraintView.tsx
@@ -1,5 +1,7 @@
 import { Paper } from '@mui/material';
 
+import { useGetProfessionsQuery } from '@/features/common/intavia-api.service';
+import { usePersonsSearchFilters } from '@/features/entities/use-persons-search-filters';
 import { Professions } from '@/features/professions/professions';
 import { LeafSizing } from '@/features/professions/professions-svg';
 import { Origin } from '@/features/visual-querying/Origin';
@@ -18,6 +20,11 @@ interface ProfessionConstraintProps {
 export function ProfessionConstraintView(props: ProfessionConstraintProps): JSX.Element {
   const { x, y, width, height, constraint } = props;
 
+  // TODO:mfranke93: This is currently not considering the filters from other
+  // constraints, but that *COULD* be considered a feature, not a bug.
+  const searchFilters = usePersonsSearchFilters();
+  const { data, isLoading } = useGetProfessionsQuery(searchFilters);
+
   // this is inside the foreignObject: completely new coordinate system
   const origin = new Origin();
 
@@ -32,11 +39,14 @@ export function ProfessionConstraintView(props: ProfessionConstraintProps): JSX.
           display: 'grid',
         }}
       >
-        <Professions
-          constraint={constraint}
-          origin={origin}
-          leafSizing={LeafSizing.QualitativeWithBar}
-        />
+        {!isLoading && (
+          <Professions
+            constraint={constraint}
+            origin={origin}
+            leafSizing={LeafSizing.QualitativeWithBar}
+            professions={data!}
+          />
+        )}
       </Paper>
     </foreignObject>
   );

--- a/src/features/visual-querying/ProfessionConstraintView.tsx
+++ b/src/features/visual-querying/ProfessionConstraintView.tsx
@@ -1,6 +1,7 @@
 import { Paper } from '@mui/material';
 
 import { Professions } from '@/features/professions/professions';
+import { Origin } from '@/features/visual-querying/Origin';
 import type { ProfessionConstraint } from '@/features/visual-querying/visualQuerying.slice';
 
 interface ProfessionConstraintProps {
@@ -10,10 +11,14 @@ interface ProfessionConstraintProps {
   width: number;
   height: number;
   constraint: ProfessionConstraint;
+  origin: Origin;
 }
 
 export function ProfessionConstraintView(props: ProfessionConstraintProps): JSX.Element {
   const { x, y, width, height, constraint } = props;
+
+  // this is inside the foreignObject: completely new coordinate system
+  const origin = new Origin();
 
   return (
     <foreignObject x={x} y={y} width={width} height={height}>
@@ -26,7 +31,7 @@ export function ProfessionConstraintView(props: ProfessionConstraintProps): JSX.
           display: 'grid',
         }}
       >
-        <Professions constraint={constraint} />
+        <Professions constraint={constraint} origin={origin} />
       </Paper>
     </foreignObject>
   );

--- a/src/features/visual-querying/VisualQuerying.tsx
+++ b/src/features/visual-querying/VisualQuerying.tsx
@@ -6,6 +6,7 @@ import { useLazyGetPersonsQuery } from '@/features/common/intavia-api.service';
 import styles from '@/features/visual-querying/visual-querying.module.css';
 import type {
   DateConstraint,
+  ProfessionConstraint,
   TextConstraint,
 } from '@/features/visual-querying/visualQuerying.slice';
 import { ConstraintType, selectConstraints } from '@/features/visual-querying/visualQuerying.slice';
@@ -38,6 +39,12 @@ export function VisualQuerying(): JSX.Element {
       ? (dateOfDeathConstraint as DateConstraint).dateRange
       : null;
 
+    const professionsConstraint = constraints.find((constraint) => {
+      return constraint.type === ConstraintType.Profession;
+    });
+    const professions =
+      (professionsConstraint as ProfessionConstraint | undefined)?.selection ?? undefined;
+
     // Send the query
     void trigger(
       {
@@ -46,6 +53,7 @@ export function VisualQuerying(): JSX.Element {
         dateOfBirthEnd: dateOfBirth ? dateOfBirth[1] : undefined,
         dateOfDeathStart: dateOfDeath ? dateOfDeath[0] : undefined,
         dateOfDeathEnd: dateOfDeath ? dateOfDeath[1] : undefined,
+        professions: JSON.stringify(professions),
       },
       true,
     );

--- a/src/features/visual-querying/visualQuerying.slice.ts
+++ b/src/features/visual-querying/visualQuerying.slice.ts
@@ -31,10 +31,10 @@ export interface TextConstraint extends Constraint {
   text: string;
 }
 
-type Profession = string; // XXX
+export type Profession = string; // XXX
 export interface ProfessionConstraint extends Constraint {
   type: ConstraintType.Profession;
-  selection: Set<Profession> | null;
+  selection: Array<Profession> | null;
 }
 
 export interface VisualQueryingState {

--- a/src/features/visual-querying/visualQuerying.slice.ts
+++ b/src/features/visual-querying/visualQuerying.slice.ts
@@ -7,6 +7,7 @@ export enum ConstraintType {
   Name = 'Name',
   DateOfBirth = 'Date of Birth',
   DateOfDeath = 'Date of Death',
+  Profession = 'Profession',
   // Place = 'Place',
 }
 
@@ -28,6 +29,12 @@ export interface DateConstraint extends Constraint {
 export interface TextConstraint extends Constraint {
   type: ConstraintType.Name;
   text: string;
+}
+
+type Profession = string; // XXX
+export interface ProfessionConstraint extends Constraint {
+  type: ConstraintType.Profession;
+  selection: Set<Profession> | null;
 }
 
 export interface VisualQueryingState {
@@ -81,11 +88,29 @@ const visualQueryingSlice = createSlice({
         constraint.text = action.payload.text;
       }
     },
+    updateProfessions: (
+      state,
+      action: PayloadAction<{ id: string; selection: ProfessionConstraint['selection'] }>,
+    ) => {
+      const constraint = state.constraints.find((constraint) => {
+        return constraint.id === action.payload.id && constraint.type === ConstraintType.Profession;
+      }) as ProfessionConstraint | undefined;
+
+      if (constraint) {
+        constraint.selection = action.payload.selection;
+      }
+    },
   },
 });
 
-export const { addConstraint, removeConstraint, toggleConstraint, updateDateRange, updateText } =
-  visualQueryingSlice.actions;
+export const {
+  addConstraint,
+  removeConstraint,
+  toggleConstraint,
+  updateDateRange,
+  updateText,
+  updateProfessions,
+} = visualQueryingSlice.actions;
 export default visualQueryingSlice.reducer;
 
 export function selectConstraints(state: RootState) {

--- a/src/mocks/db.ts
+++ b/src/mocks/db.ts
@@ -16,11 +16,17 @@ function createTable<T extends Entity>() {
   const table = new Map<T['id'], T>();
 
   const methods = {
-    findMany(q?: string | undefined, start?: [number, number], end?: [number, number]) {
+    findMany(
+      q?: string | undefined,
+      start?: [number, number],
+      end?: [number, number],
+      professions?: Array<string>,
+    ) {
       const entities = Array.from(table.values());
       let matches = q != null ? matchSorter(entities, q, { keys: ['name'] }) : entities;
       matches = start != null ? filterByEventDateRange(matches, 'beginning', start) : matches;
       matches = end != null ? filterByEventDateRange(matches, 'end', end) : matches;
+      matches = professions != null ? filterByProfession(matches, professions) : matches;
       return matches;
     },
     findById(id: T['id']) {
@@ -296,5 +302,21 @@ function filterByEventDateRange<T extends Entity>(
     }
 
     return false;
+  });
+}
+
+function filterByProfession<T extends Entity>(
+  entities: Array<T>,
+  professions: Array<string>,
+): Array<T> {
+  if (professions.length === 0) return entities;
+
+  return entities.filter((entity) => {
+    return (
+      'occupation' in entity &&
+      entity.occupation.some((d) => {
+        return professions.includes(d);
+      })
+    );
   });
 }

--- a/src/mocks/intavia-api.mocks.ts
+++ b/src/mocks/intavia-api.mocks.ts
@@ -24,7 +24,11 @@ export const handlers = [
         dateOfDeathStart != null && dateOfDeathEnd != null
           ? ([Number(dateOfDeathStart), Number(dateOfDeathEnd)] as [number, number])
           : undefined;
-      const persons = db.person.findMany(q, start, end);
+      const professionsStr = getSearchParam(request.url, 'professions');
+      const professions =
+        professionsStr !== undefined ? (JSON.parse(professionsStr) as Array<string>) : undefined;
+
+      const persons = db.person.findMany(q, start, end, professions);
 
       const limit = 10;
       const pages = Math.ceil(persons.length / limit);
@@ -141,8 +145,13 @@ export const handlers = [
         dateOfDeathStart != null && dateOfDeathEnd != null
           ? ([Number(dateOfDeathStart), Number(dateOfDeathEnd)] as [number, number])
           : undefined;
-      const persons = db.person.findMany(q, start, end);
+      const professionsStr = getSearchParam(request.url, 'professions');
+      const professions =
+        professionsStr !== undefined ? (JSON.parse(professionsStr) as Array<string>) : undefined;
 
+      const persons = db.person.findMany(q, start, end, professions);
+
+      // TODO: not feasible for the real data, a list of possible professions would be necessary here
       const allPersons = db.person.findMany();
       const allProfessions = Array.from(
         new Set<string>(

--- a/src/pages/professions.page.tsx
+++ b/src/pages/professions.page.tsx
@@ -9,6 +9,7 @@ import { useAppDispatch, useAppSelector } from '@/app/store';
 import { selectEntitiesByKind } from '@/features/common/entities.slice';
 import { Professions } from '@/features/professions/professions';
 import { ProfessionsPageHeader } from '@/features/professions/professions-page-header';
+import { Origin } from '@/features/visual-querying/Origin';
 import type { ProfessionConstraint } from '@/features/visual-querying/visualQuerying.slice';
 import {
   addConstraint,
@@ -24,6 +25,8 @@ export default function ProfessionsPage(): JSX.Element | null {
   const entities = useAppSelector(selectEntitiesByKind);
   const persons = Object.values(entities.person);
   const router = useRouter();
+
+  const origin = new Origin();
 
   useEffect(() => {
     if (persons.length === 0) {
@@ -56,7 +59,7 @@ export default function ProfessionsPage(): JSX.Element | null {
       <Container maxWidth="md" sx={{ display: 'grid', gap: 4, padding: 4 }}>
         <ProfessionsPageHeader />
         <Paper sx={{ minHeight: '50vh', display: 'grid' }}>
-          <Professions constraint={constraint} />
+          <Professions constraint={constraint} origin={origin} />
         </Paper>
       </Container>
     </Fragment>

--- a/src/pages/professions.page.tsx
+++ b/src/pages/professions.page.tsx
@@ -9,6 +9,7 @@ import { useAppDispatch, useAppSelector } from '@/app/store';
 import { selectEntitiesByKind } from '@/features/common/entities.slice';
 import { Professions } from '@/features/professions/professions';
 import { ProfessionsPageHeader } from '@/features/professions/professions-page-header';
+import { LeafSizing } from '@/features/professions/professions-svg';
 import { Origin } from '@/features/visual-querying/Origin';
 import type { ProfessionConstraint } from '@/features/visual-querying/visualQuerying.slice';
 import {
@@ -34,7 +35,7 @@ export default function ProfessionsPage(): JSX.Element | null {
     }
   }, [router, persons.length]);
 
-  // TODO: testing only
+  // for testing only
   useEffect(() => {
     const constraint: ProfessionConstraint = {
       id: 'Profession',
@@ -59,7 +60,11 @@ export default function ProfessionsPage(): JSX.Element | null {
       <Container maxWidth="md" sx={{ display: 'grid', gap: 4, padding: 4 }}>
         <ProfessionsPageHeader />
         <Paper sx={{ minHeight: '50vh', display: 'grid' }}>
-          <Professions constraint={constraint} origin={origin} />
+          <Professions
+            constraint={constraint}
+            origin={origin}
+            leafSizing={LeafSizing.QualitativeWithBar}
+          />
         </Paper>
       </Container>
     </Fragment>

--- a/src/pages/professions.page.tsx
+++ b/src/pages/professions.page.tsx
@@ -2,48 +2,25 @@ import Container from '@mui/material/Container';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import { PageMetadata } from '@stefanprobst/next-page-metadata';
-import { Fragment, useEffect } from 'react';
+import { Fragment } from 'react';
 
 import { usePageTitleTemplate } from '@/app/metadata/use-page-title-template';
-import { useAppDispatch, useAppSelector } from '@/app/store';
 import { useGetProfessionsQuery } from '@/features/common/intavia-api.service';
 import { usePersonsSearchFilters } from '@/features/entities/use-persons-search-filters';
 import { Professions } from '@/features/professions/professions';
 import { ProfessionsPageHeader } from '@/features/professions/professions-page-header';
 import { LeafSizing } from '@/features/professions/professions-svg';
 import { Origin } from '@/features/visual-querying/Origin';
-import type { ProfessionConstraint } from '@/features/visual-querying/visualQuerying.slice';
-import {
-  addConstraint,
-  ConstraintType,
-  selectConstraints,
-} from '@/features/visual-querying/visualQuerying.slice';
 
 export default function ProfessionsPage(): JSX.Element | null {
   const metadata = { title: 'Profession Hierarchy' };
 
-  const dispatch = useAppDispatch();
   const titleTemplate = usePageTitleTemplate();
 
   const searchFilters = usePersonsSearchFilters();
   const { data, isLoading } = useGetProfessionsQuery(searchFilters);
 
   const origin = new Origin();
-
-  // for testing only
-  useEffect(() => {
-    const constraint: ProfessionConstraint = {
-      id: 'Profession',
-      opened: true,
-      type: ConstraintType.Profession,
-      selection: ['Developer', 'Liaison', 'Strategist'],
-    };
-    dispatch(addConstraint(constraint));
-  }, [dispatch]);
-  const constraints = useAppSelector(selectConstraints);
-  const constraint = constraints.find((d) => {
-    return d.type === 'Profession';
-  }) as ProfessionConstraint | undefined;
 
   return (
     <Fragment>
@@ -54,12 +31,7 @@ export default function ProfessionsPage(): JSX.Element | null {
           {isLoading ? (
             <Typography role="status">Loading...</Typography>
           ) : (
-            <Professions
-              constraint={constraint}
-              origin={origin}
-              leafSizing={LeafSizing.QualitativeWithBar}
-              professions={data!}
-            />
+            <Professions origin={origin} leafSizing={LeafSizing.Quantitative} professions={data!} />
           )}
         </Paper>
       </Container>

--- a/src/pages/professions.page.tsx
+++ b/src/pages/professions.page.tsx
@@ -5,14 +5,21 @@ import { useRouter } from 'next/router';
 import { Fragment, useEffect } from 'react';
 
 import { usePageTitleTemplate } from '@/app/metadata/use-page-title-template';
-import { useAppSelector } from '@/app/store';
+import { useAppDispatch, useAppSelector } from '@/app/store';
 import { selectEntitiesByKind } from '@/features/common/entities.slice';
 import { Professions } from '@/features/professions/professions';
 import { ProfessionsPageHeader } from '@/features/professions/professions-page-header';
+import type { ProfessionConstraint } from '@/features/visual-querying/visualQuerying.slice';
+import {
+  addConstraint,
+  ConstraintType,
+  selectConstraints,
+} from '@/features/visual-querying/visualQuerying.slice';
 
 export default function ProfessionsPage(): JSX.Element | null {
   const metadata = { title: 'Profession Hierarchy' };
 
+  const dispatch = useAppDispatch();
   const titleTemplate = usePageTitleTemplate();
   const entities = useAppSelector(selectEntitiesByKind);
   const persons = Object.values(entities.person);
@@ -24,17 +31,24 @@ export default function ProfessionsPage(): JSX.Element | null {
     }
   }, [router, persons.length]);
 
+  // TODO: testing only
+  useEffect(() => {
+    const constraint: ProfessionConstraint = {
+      id: 'Profession',
+      opened: true,
+      type: ConstraintType.Profession,
+      selection: ['Developer', 'Liaison', 'Strategist'],
+    };
+    dispatch(addConstraint(constraint));
+  }, []);
+  const constraints = useAppSelector(selectConstraints);
+  const constraint = constraints.find((d) => {
+    return d.type === 'Profession';
+  }) as ProfessionConstraint | undefined;
+
   if (persons.length === 0) {
     return null;
   }
-
-  // TODO: testing only
-  const constraint = {
-    id: 'foo bar',
-    opened: true,
-    type: 'Profession',
-    selection: new Set<string>(['Developer', 'Liaison', 'Strategist']),
-  };
 
   return (
     <Fragment>

--- a/src/pages/professions.page.tsx
+++ b/src/pages/professions.page.tsx
@@ -55,7 +55,7 @@ export default function ProfessionsPage(): JSX.Element | null {
       <PageMetadata title={metadata.title} titleTemplate={titleTemplate} />
       <Container maxWidth="md" sx={{ display: 'grid', gap: 4, padding: 4 }}>
         <ProfessionsPageHeader />
-        <Paper>
+        <Paper sx={{ minHeight: '50vh', display: 'grid' }}>
           <Professions constraint={constraint} />
         </Paper>
       </Container>

--- a/src/pages/professions.page.tsx
+++ b/src/pages/professions.page.tsx
@@ -28,13 +28,21 @@ export default function ProfessionsPage(): JSX.Element | null {
     return null;
   }
 
+  // TODO: testing only
+  const constraint = {
+    id: 'foo bar',
+    opened: true,
+    type: 'Profession',
+    selection: new Set<string>(['Developer', 'Liaison', 'Strategist']),
+  };
+
   return (
     <Fragment>
       <PageMetadata title={metadata.title} titleTemplate={titleTemplate} />
       <Container maxWidth="md" sx={{ display: 'grid', gap: 4, padding: 4 }}>
         <ProfessionsPageHeader />
         <Paper>
-          <Professions />
+          <Professions constraint={constraint} />
         </Paper>
       </Container>
     </Fragment>

--- a/src/pages/professions.page.tsx
+++ b/src/pages/professions.page.tsx
@@ -1,0 +1,42 @@
+import Container from '@mui/material/Container';
+import Paper from '@mui/material/Paper';
+import { PageMetadata } from '@stefanprobst/next-page-metadata';
+import { useRouter } from 'next/router';
+import { Fragment, useEffect } from 'react';
+
+import { usePageTitleTemplate } from '@/app/metadata/use-page-title-template';
+import { useAppSelector } from '@/app/store';
+import { selectEntitiesByKind } from '@/features/common/entities.slice';
+import { Professions } from '@/features/professions/professions';
+import { ProfessionsPageHeader } from '@/features/professions/professions-page-header';
+
+export default function ProfessionsPage(): JSX.Element | null {
+  const metadata = { title: 'Profession Hierarchy' };
+
+  const titleTemplate = usePageTitleTemplate();
+  const entities = useAppSelector(selectEntitiesByKind);
+  const persons = Object.values(entities.person);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (persons.length === 0) {
+      void router.push({ pathname: '/search' });
+    }
+  }, [router, persons.length]);
+
+  if (persons.length === 0) {
+    return null;
+  }
+
+  return (
+    <Fragment>
+      <PageMetadata title={metadata.title} titleTemplate={titleTemplate} />
+      <Container maxWidth="md" sx={{ display: 'grid', gap: 4, padding: 4 }}>
+        <ProfessionsPageHeader />
+        <Paper>
+          <Professions />
+        </Paper>
+      </Container>
+    </Fragment>
+  );
+}

--- a/src/pages/professions.page.tsx
+++ b/src/pages/professions.page.tsx
@@ -40,7 +40,7 @@ export default function ProfessionsPage(): JSX.Element | null {
       selection: ['Developer', 'Liaison', 'Strategist'],
     };
     dispatch(addConstraint(constraint));
-  }, []);
+  }, [dispatch]);
   const constraints = useAppSelector(selectConstraints);
   const constraint = constraints.find((d) => {
     return d.type === 'Profession';


### PR DESCRIPTION
This can be used both to visualize the distribution on professions of an existing result set (e.g., in the coordinated page), or as a filter in the visual querying page. In the latter case, the hierarchy nodes can be clicked, show a text node, and show the number of persons with that profession as a bar in the leaf nodes.
The profession constraint is also applied to the query filters. This PR also adds a mock API endpoint for all professions used in the mock data, and assigns them to a mock hierarchy based on their first letter. 