### PR TITLE
chore: enable new prettier cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -119,7 +119,7 @@
         "postcss": "^8.4.8",
         "postcss-custom-media": "^8.0.0",
         "postcss-nesting": "^10.1.3",
-        "prettier": "^2.6.0",
+        "prettier": "^2.7.0",
         "simple-git-hooks": "^2.7.0",
         "start-server-and-test": "^1.14.0",
         "stylelint": "^14.6.0",
@@ -31425,9 +31425,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
-      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.0.tgz",
+      "integrity": "sha512-nwoX4GMFgxoPC6diHvSwmK/4yU8FFH3V8XWtLQrbj4IBsK2pkYhG4kf/ljF/haaZ/aii+wNJqISrCDPgxGWDVQ==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -61522,9 +61522,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
-      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.0.tgz",
+      "integrity": "sha512-nwoX4GMFgxoPC6diHvSwmK/4yU8FFH3V8XWtLQrbj4IBsK2pkYhG4kf/ljF/haaZ/aii+wNJqISrCDPgxGWDVQ==",
       "dev": true
     },
     "pretty-bytes": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "cypress": "cypress open --config-file ./cypress/cypress.config.json",
     "cypress:headless": "cypress run --config-file ./cypress/cypress.config.json",
     "dev": "next dev",
-    "format": "prettier . --list-different --ignore-path .gitignore",
+    "format": "prettier . --cache --check --ignore-path .gitignore",
     "format:fix": "npm run format -- --write",
     "generate:favicons": "ts-script scripts/generate-favicons",
     "generate:msw": "msw init public",
@@ -153,7 +153,7 @@
     "postcss": "^8.4.8",
     "postcss-custom-media": "^8.0.0",
     "postcss-nesting": "^10.1.3",
-    "prettier": "^2.6.0",
+    "prettier": "^2.7.0",
     "simple-git-hooks": "^2.7.0",
     "start-server-and-test": "^1.14.0",
     "stylelint": "^14.6.0",
@@ -368,13 +368,13 @@
   "lint-staged": {
     "*.@(cjs|js|mjs|ts|tsx)": [
       "eslint --cache --cache-location .next/cache/eslint/ --fix",
-      "prettier --write"
+      "prettier --cache --write"
     ],
     "*.css": [
       "stylelint --cache --cache-location .next/cache/stylelint/ --fix",
-      "prettier --write"
+      "prettier --cache --write"
     ],
-    "*.@(json|md)": "prettier --write"
+    "*.@(json|md)": "prettier --cache --write"
   },
   "msw": {
     "workerDirectory": "public"


### PR DESCRIPTION
`prettier` got a new `--cache` option in v2.7. let's use it.