### PR TITLE
fix a test sometimes failing on some machines

### DIFF
--- a/test/pages/timeline.page.test.tsx
+++ b/test/pages/timeline.page.test.tsx
@@ -125,10 +125,13 @@ describe('TimelinePage', () => {
     expect(tooltip).toBeInTheDocument();
 
     await userEvent.unhover(timelineItemOne);
-    await waitFor(() => {
-      const tooltip = screen.queryByRole('tooltip');
-      expect(tooltip).not.toBeInTheDocument();
-    });
+    await waitFor(
+      () => {
+        const tooltip = screen.queryByRole('tooltip');
+        expect(tooltip).not.toBeInTheDocument();
+      },
+      { timeout: 3000 },
+    );
   });
 
   it('should show person relations in the tooltip', async () => {


### PR DESCRIPTION
Due to timing issues, waitFor() sometimes gave up before the tooltip was
removed from the DOM after un-hovering the element. This made a test of the
timeline page fail intermittently. This commit seems to fix the issue, by
increasing the timeout of that specific waitFor() function from 1s (the
default) to 3s.

re #66
closes #66