### PR TITLE
chore: add prettier-plugin-tailwindcss

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -127,6 +127,7 @@
         "postcss-custom-media": "^8.0.0",
         "postcss-nesting": "^10.1.3",
         "prettier": "^2.7.0",
+        "prettier-plugin-tailwindcss": "^0.1.11",
         "simple-git-hooks": "^2.7.0",
         "start-server-and-test": "^1.14.0",
         "stylelint": "^14.6.0",
@@ -31460,6 +31461,18 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.1.11.tgz",
+      "integrity": "sha512-a28+1jvpIZQdZ/W97wOXb6VqI762MKE/TxMMuibMEHhyYsSxQA8Ek30KObd5kJI2HF1ldtSYprFayXJXi3pz8Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.17.0"
+      },
+      "peerDependencies": {
+        "prettier": ">=2.2.0"
+      }
+    },
     "node_modules/pretty-bytes": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
@@ -61642,6 +61655,12 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.0.tgz",
       "integrity": "sha512-nwoX4GMFgxoPC6diHvSwmK/4yU8FFH3V8XWtLQrbj4IBsK2pkYhG4kf/ljF/haaZ/aii+wNJqISrCDPgxGWDVQ==",
+      "dev": true
+    },
+    "prettier-plugin-tailwindcss": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.1.11.tgz",
+      "integrity": "sha512-a28+1jvpIZQdZ/W97wOXb6VqI762MKE/TxMMuibMEHhyYsSxQA8Ek30KObd5kJI2HF1ldtSYprFayXJXi3pz8Q==",
       "dev": true
     },
     "pretty-bytes": {

--- a/package.json
+++ b/package.json
@@ -161,6 +161,7 @@
     "postcss-custom-media": "^8.0.0",
     "postcss-nesting": "^10.1.3",
     "prettier": "^2.7.0",
+    "prettier-plugin-tailwindcss": "^0.1.11",
     "simple-git-hooks": "^2.7.0",
     "start-server-and-test": "^1.14.0",
     "stylelint": "^14.6.0",


### PR DESCRIPTION
this adds the prettier-plugin for tailwindcss, which enforces consistent classname order.