### PR TITLE
Merge visualization state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ public/site.webmanifest
 
 # package-lock.json (for now)
 /package-lock.json
+public/hofburg/*

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "@stefanprobst/next-i18n": "1.2.0-legacy",
     "@stefanprobst/next-page-metadata": "2.0.5-legacy",
     "@stefanprobst/request": "^0.1.10",
-    "@tailwindcss/line-clamp": "^0.4.0",
     "@turf/turf": "^6.5.0",
     "allotment": "^1.14.2",
     "clsx": "^1.2.0",
@@ -96,6 +95,7 @@
     "redux-persist": "^6.0.0",
     "sharp": "^0.30.4",
     "tailwindcss": "^3.1.4",
+    "uuid": "^8.3.2",
     "xlsx": "^0.18.5",
     "zod": "^3.15.1"
   },
@@ -117,6 +117,7 @@
     "@storybook/manager-webpack5": "^6.4.19",
     "@storybook/react": "^6.4.19",
     "@storybook/testing-library": "^0.0.9",
+    "@tailwindcss/line-clamp": "^0.4.0",
     "@testing-library/cypress": "^8.0.2",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.4",

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -23,6 +23,7 @@ import intaviaApiService from '@/features/common/intavia-api.service';
 import visualizationReducer from '@/features/common/visualization.slice';
 import searchHistoryReducer from '@/features/entities/search-history.slice';
 import searchResultsSelectionReducer from '@/features/entities/search-results-selection.slice';
+import contentPaneReducer from '@/features/storycreator/contentPane.slice';
 import storycreatorReducer from '@/features/storycreator/storycreator.slice';
 import timelineReducer, { setTimeRangeBrush } from '@/features/timeline/timeline.slice';
 import uiReducer from '@/features/ui/ui.slice';
@@ -55,6 +56,7 @@ export function configureAppStore() {
       ui: uiReducer,
       visualQuerying: visualQueryingReducer,
       visualization: visualizationReducer,
+      contentPane: contentPaneReducer,
       workspaces: workspacesReducer,
     },
     middleware(getDefaultMiddleware) {

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -20,12 +20,14 @@ import errorMiddleware from '@/app/error.middleware';
 import notificationsReducer, { addNotification } from '@/app/notifications/notifications.slice';
 import entitiesReducer from '@/features/common/entities.slice';
 import intaviaApiService from '@/features/common/intavia-api.service';
+import visualizationReducer from '@/features/common/visualization.slice';
 import searchHistoryReducer from '@/features/entities/search-history.slice';
 import searchResultsSelectionReducer from '@/features/entities/search-results-selection.slice';
 import storycreatorReducer from '@/features/storycreator/storycreator.slice';
 import timelineReducer, { setTimeRangeBrush } from '@/features/timeline/timeline.slice';
 import uiReducer from '@/features/ui/ui.slice';
 import visualQueryingReducer from '@/features/visual-querying/visualQuerying.slice';
+import workspacesReducer from '@/features/visualization-layouts/workspaces.slice';
 
 const persistConfig = {
   key: 'entities',
@@ -52,6 +54,8 @@ export function configureAppStore() {
       timeline: timelineReducer,
       ui: uiReducer,
       visualQuerying: visualQueryingReducer,
+      visualization: visualizationReducer,
+      workspaces: workspacesReducer,
     },
     middleware(getDefaultMiddleware) {
       return getDefaultMiddleware({

--- a/src/features/common/entity.model.ts
+++ b/src/features/common/entity.model.ts
@@ -8,6 +8,7 @@ export interface EntityBase {
 }
 
 export interface EntityEvent {
+  id: string;
   type: EventType;
   targetId?: Entity['id'];
   date?: IsoDateString;

--- a/src/features/common/entity.model.ts
+++ b/src/features/common/entity.model.ts
@@ -17,6 +17,7 @@ export interface EntityEvent {
 
 export interface StoryEvent {
   type: string;
+  targetId?: Entity['id'];
   date?: IsoDateString;
   place?: Place;
   label?: string;

--- a/src/features/common/visualization.slice.ts
+++ b/src/features/common/visualization.slice.ts
@@ -1,0 +1,98 @@
+import type { PayloadAction } from '@reduxjs/toolkit';
+import { createSelector, createSlice } from '@reduxjs/toolkit';
+
+import type { RootState } from '@/app/store';
+import type { Entity, EntityEvent, StoryEvent } from '@/features/common/entity.model';
+
+export interface Visualization {
+  id: string;
+  type: 'map' | 'timeline';
+  name: string;
+  entityIds: Array<Entity['id']>;
+  eventIds: Array<EntityEvent | StoryEvent>;
+  props: Record<string, unknown>;
+}
+
+const initialState: Record<Visualization['id'], Visualization> = {
+  'vis-1': {
+    id: 'vis-1',
+    type: 'map',
+    name: "Vegerio's Life",
+    entityIds: ['abc', 'def'],
+    eventIds: [],
+    props: {
+      mapStyle: 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json',
+      initialViewState: {
+        longitude: 7.571606,
+        latitude: 50.226913,
+        zoom: 4,
+      },
+    },
+  },
+  'vis-2': {
+    id: 'vis-2',
+    type: 'map',
+    name: 'Dürer',
+    entityIds: ['abc', 'def'],
+    eventIds: [],
+    props: {
+      mapStyle: 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json',
+      initialViewState: {
+        longitude: 8.571606,
+        latitude: 50.226913,
+        zoom: 9,
+      },
+    },
+  },
+};
+
+const visualizationSlice = createSlice({
+  name: 'visualization',
+  initialState,
+  reducers: {
+    removeVisualization: (state, action: PayloadAction<Visualization['id']>) => {
+      const id = action.payload;
+      delete state[id];
+    },
+    createVisualization: (state, action: PayloadAction<Visualization>) => {
+      const vis = action.payload;
+      state[vis['id']] = vis;
+    },
+  },
+});
+
+export const { removeVisualization, createVisualization } = visualizationSlice.actions;
+
+export const selectVisualizationById = createSelector(
+  (state: RootState) => {
+    return state.visualization;
+  },
+  (state: RootState, id: Visualization['id']) => {
+    return id;
+  },
+  (visualizations, id) => {
+    return visualizations[id];
+  },
+);
+
+export const selectVisualizationsByType = createSelector(
+  (state: RootState) => {
+    return state.visualization;
+  },
+  (state: RootState, type: Visualization['type']) => {
+    return type;
+  },
+  (visualizations, type) => {
+    return Object.fromEntries(
+      Object.entries(visualizations).filter((vis) => {
+        return vis[1].type === type;
+      }),
+    );
+  },
+);
+
+export const selectAllVisualizations = (state: RootState) => {
+  return state.visualization;
+};
+
+export default visualizationSlice.reducer;

--- a/src/features/common/visualization.slice.ts
+++ b/src/features/common/visualization.slice.ts
@@ -2,16 +2,26 @@ import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSelector, createSlice } from '@reduxjs/toolkit';
 
 import type { RootState } from '@/app/store';
-import type { Entity, EntityEvent, StoryEvent } from '@/features/common/entity.model';
+import type { Entity, Person } from '@/features/common/entity.model';
 
 export interface Visualization {
   id: string;
-  type: 'map' | 'timeline';
+  type: 'map' | 'story-map' | 'story-timeline' | 'timeline';
   name: string;
   entityIds: Array<Entity['id']>;
-  eventIds: Array<EntityEvent | StoryEvent>;
+  eventIds: Array<string>;
   props: Record<string, unknown>;
 }
+
+//TODO Add real properties to the visualization and the module dialog to edit them
+/* export interface VisualisationProperty {
+  type: 'select' | 'text' | 'textarea';
+  id: string;
+  label: string;
+  value: string;
+  editable: boolean | false;
+  sort: number | 0;
+} */
 
 const initialState: Record<Visualization['id'], Visualization> = {
   'vis-1': {
@@ -58,10 +68,31 @@ const visualizationSlice = createSlice({
       const vis = action.payload;
       state[vis['id']] = vis;
     },
+    addPersonToVisualization: (state, action) => {
+      const person = action.payload.person as Person;
+      const visId = action.payload.visId;
+
+      if (!state[visId]!.entityIds.includes(person.id)) {
+        state[visId]!.entityIds.push(person.id);
+      }
+    },
+    addEventToVisualization: (state, action) => {
+      const event = action.payload.event;
+      const visId = action.payload.visId;
+
+      if (!state[visId]!.eventIds.includes(event.id)) {
+        state[visId]!.eventIds.push(event.id);
+      }
+    },
   },
 });
 
-export const { removeVisualization, createVisualization } = visualizationSlice.actions;
+export const {
+  removeVisualization,
+  createVisualization,
+  addEventToVisualization,
+  addPersonToVisualization,
+} = visualizationSlice.actions;
 
 export const selectVisualizationById = createSelector(
   (state: RootState) => {

--- a/src/features/entities/collection-panel-entry.tsx
+++ b/src/features/entities/collection-panel-entry.tsx
@@ -8,9 +8,13 @@ import { formatDate } from '@/lib/format-date';
 
 export interface CollectionPanelEntryProps {
   entity: Entity;
+  draggable?: boolean;
+  mini?: boolean;
 }
 
 export default function CollectionPanelEntry(props: CollectionPanelEntryProps): JSX.Element {
+  const { draggable = false, mini = false } = props;
+
   //const isPerson = props.entity.kind === 'person';
   const isPerson = parseInt(props.entity.id) % 2 === 0;
   const [fgColor, bgColor, symbol] = isPerson
@@ -19,7 +23,7 @@ export default function CollectionPanelEntry(props: CollectionPanelEntryProps): 
     : // eslint-disable-next-line react/jsx-key
       ['text-blue-900', 'bg-blue-100', <LocationMarkerIcon />];
   return (
-    <div className={`my-2 mx-1 rounded border-2 border-current p-2 ${fgColor} ${bgColor}`}>
+    <div className={`my-1 mx-1 rounded border-2 border-current p-2 ${fgColor} ${bgColor}`}>
       <Disclosure>
         {({ open }) => {
           let content = '';
@@ -36,25 +40,55 @@ export default function CollectionPanelEntry(props: CollectionPanelEntryProps): 
 
           return (
             <Fragment>
-              <Disclosure.Button className="display-block py-2">
-                <div className="mb-3 grid grid-cols-[3.6rem_1fr_minmax(50px,max-content)] grid-rows-3 gap-1">
-                  <div className={`col-start-1 row-span-3 row-start-1 ${fgColor}`}>{symbol}</div>
-                  <h2 className="col-start-2 row-span-3 row-start-1 my-1 place-self-center text-lg font-semibold">
-                    {props.entity.name}
-                  </h2>
-                  <span className="font-verythin col-start-3 row-start-1 max-w-[20ch] justify-self-end overflow-hidden text-ellipsis whitespace-nowrap text-[0.65rem]">
-                    {props.entity.kind === 'person' ? props.entity.categories.join(', ') : ''}
-                  </span>
-                  <span className="font-verythin col-start-3 row-start-2 max-w-[20ch] justify-self-end overflow-hidden text-ellipsis whitespace-nowrap text-[0.65rem]">
-                    {content}
-                  </span>
-                  <span className="font-verythin col-start-3 row-start-3 max-w-[20ch] justify-self-end overflow-hidden text-ellipsis whitespace-nowrap text-[0.65rem]">
-                    {props.entity.kind === 'person' ? props.entity.occupation.join(', ') : ''}
-                  </span>
-                </div>
+              <Disclosure.Button className={`display-block w-full ${mini ? '' : 'py-2'}`}>
+                <div
+                  draggable={draggable}
+                  onDragStart={(event) => {
+                    return event.dataTransfer.setData(
+                      'Text',
+                      JSON.stringify({
+                        type: 'Person',
+                        props: props.entity,
+                        content: '',
+                      }),
+                    );
+                  }}
+                >
+                  <div
+                    className={`{mb-3 grid ${
+                      mini
+                        ? 'grid-cols-[2em_auto_auto] grid-rows-2'
+                        : 'grid-cols-[3.6rem_1fr_minmax(20px,max-content)] grid-rows-3'
+                    }`}
+                  >
+                    <div className={`col-start-1 row-span-3 row-start-1 ${fgColor}`}>{symbol}</div>
+                    <h2
+                      className={`col-start-2 ${
+                        mini ? 'row-span-2' : 'row-span-3'
+                      } row-start-1 my-1 ${
+                        mini ? 'text-sm' : 'text-lg'
+                      } place-self-center font-semibold`}
+                    >
+                      {props.entity.name}
+                    </h2>
+                    <span className="font-verythin col-start-3 row-start-1 max-w-[20ch] justify-self-end overflow-hidden text-ellipsis whitespace-nowrap text-[0.65rem]">
+                      {content}
+                    </span>
+                    <span className="font-verythin col-start-3 row-start-2 max-w-[20ch] justify-self-end overflow-hidden text-ellipsis whitespace-nowrap text-[0.65rem]">
+                      {props.entity.kind === 'person' ? props.entity.occupation.join(', ') : ''}
+                    </span>
+                    {!mini && (
+                      <span className="font-verythin col-start-3 row-start-3 max-w-[20ch] justify-self-end overflow-hidden text-ellipsis whitespace-nowrap text-[0.65rem]">
+                        {props.entity.kind === 'person' ? props.entity.categories.join(', ') : ''}
+                      </span>
+                    )}
+                  </div>
 
-                <div className={`${open ? '' : `contrast-[.2] line-clamp-2`} text-justify`}>
-                  <p>{props.entity.description}</p>
+                  {(!mini || open) && (
+                    <div className={`${open ? '' : `contrast-[.2] line-clamp-2`} text-justify`}>
+                      <p>{props.entity.description}</p>
+                    </div>
+                  )}
                 </div>
               </Disclosure.Button>
               <Disclosure.Panel>
@@ -62,19 +96,35 @@ export default function CollectionPanelEntry(props: CollectionPanelEntryProps): 
                   <Fragment>
                     <h3 className="text-lg font-semibold">Events</h3>
 
-                    <div className="grid grid-cols-[max-content_1fr] justify-items-start gap-1">
+                    <div className="table">
                       {props.entity.history?.map((event, index) => {
                         // TODO: events should have label and description
                         return (
-                          <Fragment key={index}>
-                            <span className="font-semibold">{eventTypes[event.type].label}</span>{' '}
-                            <span>
+                          <div
+                            draggable={draggable}
+                            onDragStart={(dragEvent) => {
+                              return dragEvent.dataTransfer.setData(
+                                'Text',
+                                JSON.stringify({
+                                  type: 'Event',
+                                  props: event,
+                                  content: '',
+                                }),
+                              );
+                            }}
+                            className="table-row justify-items-start gap-1"
+                            key={index}
+                          >
+                            <div className="table-cell w-1/3 font-semibold">
+                              {eventTypes[event.type].label}
+                            </div>
+                            <div className="table-cell">
                               {event.date != null ? (
                                 <span>{formatDate(new Date(event.date))}</span>
                               ) : null}{' '}
                               {event.place != null ? <span>in {event.place.name}</span> : null}
-                            </span>
-                          </Fragment>
+                            </div>
+                          </div>
                         );
                       })}
                     </div>

--- a/src/features/entities/collection-panel.tsx
+++ b/src/features/entities/collection-panel.tsx
@@ -1,13 +1,20 @@
 import CollectionPanelEntry from '@/features/entities/collection-panel-entry';
 import { usePersonsSearchResults } from '@/features/entities/use-persons-search-results';
 
-export function CollectionPanel(): JSX.Element {
+interface CollectionPanelProps {
+  draggable?: boolean;
+  mini?: boolean;
+}
+
+export function CollectionPanel(props: CollectionPanelProps): JSX.Element {
   const searchResults = usePersonsSearchResults();
+
+  const { draggable = false, mini = false } = props;
 
   return (
     <div className="grid grid-flow-row">
       {searchResults.data?.entities.map((d) => {
-        return <CollectionPanelEntry key={d.id} entity={d} />;
+        return <CollectionPanelEntry key={d.id} entity={d} draggable={draggable} mini={mini} />;
       })}
     </div>
   );

--- a/src/features/excel-upload/ExcelUpload.tsx
+++ b/src/features/excel-upload/ExcelUpload.tsx
@@ -7,11 +7,10 @@ import type { ChangeEvent } from 'react';
 import * as XLSX from 'xlsx';
 
 import { useAppDispatch } from '@/app/store';
-import { addLocalEntity } from '@/features/common/entities.slice';
-import type { Person, Place, StoryEvent } from '@/features/common/entity.model';
+import type { Place, StoryEvent } from '@/features/common/entity.model';
 import styles from '@/features/storycreator/storycreator.module.css';
 
-import type { Slide, SlideContent, VisualisationPane } from '../storycreator/storycreator.slice';
+import type { Slide, SlideContent } from '../storycreator/storycreator.slice';
 import { setSlidesForStory } from '../storycreator/storycreator.slice';
 
 interface ExcelUploadProps {
@@ -67,11 +66,11 @@ export function ExcelUpload(props: ExcelUploadProps): JSX.Element {
     //   };
     // });
 
-    convertData(list);
+    //convertData(list);
     /* convertDataHofburg(list); */
   }
 
-  function convertData(data: Array<any>) {
+  /* function convertData(data: Array<any>) {
     const events: Array<StoryEvent> = [];
 
     for (const raw of data) {
@@ -113,7 +112,7 @@ export function ExcelUpload(props: ExcelUploadProps): JSX.Element {
     } as Person;
 
     dispatch(addLocalEntity(person));
-  }
+  } */
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   function convertDataHofburg(data: Array<any>) {
@@ -244,7 +243,7 @@ export function ExcelUpload(props: ExcelUploadProps): JSX.Element {
         index = index + 1;
       }
 
-      const text = textInSlides[slideNumber] as string;
+      /* const text = textInSlides[slideNumber] as string;
       const textInSlide: Record<SlideContent['id'], SlideContent> = {
         text0: {
           type: 'Text',
@@ -275,13 +274,13 @@ export function ExcelUpload(props: ExcelUploadProps): JSX.Element {
             },
           },
         },
-      };
+      }; */
 
       const slide: Slide = {
         id: `slide${slideNumber}`,
         sort: parseInt(slideNumber),
         story: storyID,
-        visualizationPanes: {
+        /* visualizationPanes: {
           vis0: {
             id: 'vis0',
             type: 'Map',
@@ -321,8 +320,10 @@ export function ExcelUpload(props: ExcelUploadProps): JSX.Element {
             id: 'contentPane1',
             contents: {},
           },
-        },
-        layout: 'singleviscontent',
+        }, */
+        visualizationSlots: { 'vis-1': null, 'vis-2': null, 'vis-3': null, 'vis-4': null },
+        contentPaneSlots: { 'cont-1': null, 'cont-2': null },
+        layout: 'single-vis-content',
       };
 
       slides[`slide${slideNumber}`] = slide;

--- a/src/features/storycreator/DroppableIcon.tsx
+++ b/src/features/storycreator/DroppableIcon.tsx
@@ -1,10 +1,12 @@
+import {
+  ChartBarIcon,
+  ChatIcon,
+  DocumentTextIcon,
+  MapIcon,
+  PhotographIcon,
+} from '@heroicons/react/outline';
 import AdjustIcon from '@mui/icons-material/Adjust';
-import ImageOutlinedIcon from '@mui/icons-material/ImageOutlined';
-import LinearScaleOutlinedIcon from '@mui/icons-material/LinearScaleOutlined';
-import MapOutlinedIcon from '@mui/icons-material/MapOutlined';
-import NoteAltOutlinedIcon from '@mui/icons-material/NoteAltOutlined';
 import PersonOutlineOutlinedIcon from '@mui/icons-material/PersonOutlineOutlined';
-import QuizOutlinedIcon from '@mui/icons-material/QuizOutlined';
 
 import styles from '@/features/ui/ui.module.css';
 
@@ -15,41 +17,13 @@ export interface DroppableIconProps {
 const getIcon: any = (type: string) => {
   switch (type) {
     case 'Timeline':
-      return (
-        <LinearScaleOutlinedIcon
-          className={styles['droppable-icon']}
-          fontSize="large"
-          color="primary"
-          key="timelineIcon"
-        />
-      );
+      return <ChartBarIcon className="h-6 w-6 -rotate-90 text-intavia-brand-800" />;
     case 'Map':
-      return (
-        <MapOutlinedIcon
-          className={styles['droppable-icon']}
-          fontSize="large"
-          color="primary"
-          key="mapIcon"
-        />
-      );
+      return <MapIcon className="h-6 w-6 text-intavia-brand-800" />;
     case 'Text':
-      return (
-        <NoteAltOutlinedIcon
-          className={styles['droppable-icon']}
-          fontSize="large"
-          color="primary"
-          key="annotationIcon"
-        />
-      );
+      return <DocumentTextIcon className="h-6 w-6 text-intavia-brand-800" />;
     case 'Image':
-      return (
-        <ImageOutlinedIcon
-          className={styles['droppable-icon']}
-          fontSize="large"
-          color="primary"
-          key="imageIcon"
-        />
-      );
+      return <PhotographIcon className="h-6 w-6 text-intavia-brand-800" />;
     case 'Person':
       return (
         <PersonOutlineOutlinedIcon
@@ -59,14 +33,7 @@ const getIcon: any = (type: string) => {
         />
       );
     case 'Quiz':
-      return (
-        <QuizOutlinedIcon
-          className={styles['droppable-icon']}
-          fontSize="large"
-          color="primary"
-          key="EventIcon"
-        />
-      );
+      return <ChatIcon className="h-6 w-6 text-intavia-brand-800" />;
     case 'Event':
       return <AdjustIcon className={styles['droppable-icon']} color="primary" key="EventIcon" />;
     default:

--- a/src/features/storycreator/SlideEditor.tsx
+++ b/src/features/storycreator/SlideEditor.tsx
@@ -6,7 +6,6 @@ import ReactResizeDetector from 'react-resize-detector';
 import { useAppDispatch, useAppSelector } from '@/app/store';
 import { StoryContentDialog } from '@/features/storycreator/StoryContentDialog';
 import { StoryContentPane } from '@/features/storycreator/StoryContentPane';
-import styles from '@/features/storycreator/storycreator.module.css';
 import type { Slide } from '@/features/storycreator/storycreator.slice';
 import {
   addContentToContentPane,
@@ -17,16 +16,18 @@ import type { UiWindow } from '@/features/ui/ui.slice';
 import { selectWindows } from '@/features/ui/ui.slice';
 
 interface SlideEditorProps {
-  width: number | undefined;
-  height: number | undefined; // FIXME: unused
-  targetRef: RefObject<HTMLDivElement>;
+  width?: number | undefined;
+  height?: number | undefined; // FIXME: unused
+  targetRef?: RefObject<HTMLDivElement>;
   /* imageRef: RefObject<HTMLDivElement>; */
   slide: Slide;
-  takeScreenshot: () => void;
+  takeScreenshot?: () => void;
   numberOfVisPanes: number;
   numberOfContentPanes: number;
-  vertical: boolean;
+  vertical?: boolean;
   increaseNumberOfContentPanes: () => void;
+  desktop?: boolean;
+  timescale?: boolean;
 }
 
 interface DropProps {
@@ -42,8 +43,10 @@ export function SlideEditor(props: SlideEditorProps) {
     /* imageRef, */
     numberOfContentPanes,
     numberOfVisPanes,
-    vertical,
+    vertical = false,
     increaseNumberOfContentPanes,
+    //desktop = false,
+    timescale = false,
   } = props;
   const [openDialog, setOpenDialog] = useState(false);
 
@@ -63,6 +66,7 @@ export function SlideEditor(props: SlideEditorProps) {
 
   const onDropContentPane = (i_layout: any, i_layoutItem: any, event: any, i_targetPane: any) => {
     const dropProps: DropProps = JSON.parse(event.dataTransfer.getData('text'));
+
     const layoutItem = i_layoutItem;
 
     let targetPane = i_targetPane;
@@ -172,26 +176,33 @@ export function SlideEditor(props: SlideEditorProps) {
     });
 
     return (
-      <Allotment>
-        <Allotment.Pane visible={visPanes.length > 0 ? true : false}>
-          <Allotment
-            key={`alottmentForVis${vertical}`}
-            /* Force the layout to repaint */ vertical={vertical ? false : true}
-          >
-            {visPanes.map((vis, index) => {
-              return <Allotment.Pane key={index}>{vis}</Allotment.Pane>;
-            })}
+      <Allotment vertical={true}>
+        <Allotment.Pane>
+          <Allotment>
+            <Allotment.Pane visible={visPanes.length > 0 ? true : false}>
+              <Allotment
+                key={`alottmentForVis${vertical}`}
+                /* Force the layout to repaint */ vertical={vertical ? false : true}
+              >
+                {visPanes.map((vis, index) => {
+                  return <Allotment.Pane key={index}>{vis}</Allotment.Pane>;
+                })}
+              </Allotment>
+            </Allotment.Pane>
+            <Allotment.Pane preferredSize={'33%'} visible={contentPanes.length > 0 ? true : false}>
+              <Allotment
+                key={`alottmentForContent${vertical}`} //Force the layout to repaint
+                vertical={vertical ? false : true}
+              >
+                {contentPanes.map((content, index) => {
+                  return <Allotment.Pane key={index}>{content}</Allotment.Pane>;
+                })}
+              </Allotment>
+            </Allotment.Pane>
           </Allotment>
         </Allotment.Pane>
-        <Allotment.Pane visible={contentPanes.length > 0 ? true : false}>
-          <Allotment
-            key={`alottmentForContent${vertical}`} //Force the layout to repaint
-            vertical={vertical ? false : true}
-          >
-            {contentPanes.map((content, index) => {
-              return <Allotment.Pane key={index}>{content}</Allotment.Pane>;
-            })}
-          </Allotment>
+        <Allotment.Pane maxSize={50} key={`${timescale}`} visible={timescale}>
+          <div className="h-full w-full bg-intavia-red-200" />
         </Allotment.Pane>
       </Allotment>
     );
@@ -199,7 +210,8 @@ export function SlideEditor(props: SlideEditorProps) {
 
   return (
     /* innerref={imageRef} */
-    <div ref={targetRef} className={styles['slide-editor-wrapper']}>
+    // className={styles['slide-editor-wrapper']}
+    <div ref={targetRef} className="h-full">
       {createSplitterLayout()}
       {editElement != null && (
         <StoryContentDialog

--- a/src/features/storycreator/SlideEditor.tsx
+++ b/src/features/storycreator/SlideEditor.tsx
@@ -1,19 +1,24 @@
-import { Allotment } from 'allotment';
 import type { RefObject } from 'react';
 import { useState } from 'react';
-import ReactResizeDetector from 'react-resize-detector';
 
 import { useAppDispatch, useAppSelector } from '@/app/store';
-import { StoryContentDialog } from '@/features/storycreator/StoryContentDialog';
-import { StoryContentPane } from '@/features/storycreator/StoryContentPane';
-import type { Slide } from '@/features/storycreator/storycreator.slice';
 import {
   addContentToContentPane,
+  createContentPane,
   editSlideContent,
+} from '@/features/storycreator/contentPane.slice';
+import { StoryContentDialog } from '@/features/storycreator/StoryContentDialog';
+import type { Slide } from '@/features/storycreator/storycreator.slice';
+import {
+  releaseVisualizationForVisualizationSlotForSlide,
+  setContentPaneToSlot,
+  setVisualizationForVisualizationSlotForStorySlide,
+  switchVisualizations,
 } from '@/features/storycreator/storycreator.slice';
-import { StoryVisPane } from '@/features/storycreator/StoryVisPane';
+import type { PanelLayout } from '@/features/ui/analyse-page-toolbar/layout-popover';
 import type { UiWindow } from '@/features/ui/ui.slice';
 import { selectWindows } from '@/features/ui/ui.slice';
+import VisualizationGroup from '@/features/visualization-layouts/visualization-group';
 
 interface SlideEditorProps {
   width?: number | undefined;
@@ -22,12 +27,13 @@ interface SlideEditorProps {
   /* imageRef: RefObject<HTMLDivElement>; */
   slide: Slide;
   takeScreenshot?: () => void;
-  numberOfVisPanes: number;
-  numberOfContentPanes: number;
+  numberOfVisPanes?: number;
+  numberOfContentPanes?: number;
   vertical?: boolean;
   increaseNumberOfContentPanes: () => void;
   desktop?: boolean;
   timescale?: boolean;
+  layout: PanelLayout;
 }
 
 interface DropProps {
@@ -41,12 +47,11 @@ export function SlideEditor(props: SlideEditorProps) {
     targetRef,
     slide,
     /* imageRef, */
-    numberOfContentPanes,
+    /*  numberOfContentPanes,
     numberOfVisPanes,
-    vertical = false,
-    increaseNumberOfContentPanes,
+    vertical = false, */
+    layout,
     //desktop = false,
-    timescale = false,
   } = props;
   const [openDialog, setOpenDialog] = useState(false);
 
@@ -63,6 +68,25 @@ export function SlideEditor(props: SlideEditorProps) {
   };
 
   const windows = useAppSelector(selectWindows);
+
+  const onSwitchVisualization = (
+    targetSlot: string,
+    targetVis: string | null,
+    sourceSlot: string,
+    sourceVis: string | null,
+  ) => {
+    dispatch(switchVisualizations({ targetSlot, targetVis, sourceSlot, sourceVis, slide }));
+  };
+
+  const onAddContentPane = (slotId: string) => {
+    const contId = `contentPane-${Math.random()
+      .toString(36)
+      .replace(/[^a-z]+/g, '')
+      .substring(0, 4)}`;
+
+    dispatch(setContentPaneToSlot({ id: contId, slotId: slotId, slide }));
+    dispatch(createContentPane({ id: contId }));
+  };
 
   const onDropContentPane = (i_layout: any, i_layoutItem: any, event: any, i_targetPane: any) => {
     const dropProps: DropProps = JSON.parse(event.dataTransfer.getData('text'));
@@ -94,7 +118,7 @@ export function SlideEditor(props: SlideEditorProps) {
         layoutItem['w'] = 1;
         break;
       default:
-        layoutItem['h'] = 4;
+        layoutItem['h'] = 1;
         layoutItem['w'] = 1;
         break;
     }
@@ -116,103 +140,38 @@ export function SlideEditor(props: SlideEditorProps) {
     );
   };
 
-  const createSplitterLayout = () => {
-    const visKeys = Object.keys(slide.visualizationPanes) as Array<string>;
-    const visualizations = [];
-    for (let i = 0; i < numberOfVisPanes; i++) {
-      visualizations.push(slide.visualizationPanes[visKeys[i] as string]);
-    }
-
-    const contentPanesInSlide = Object.values(slide.contentPanes);
-    const contents = [];
-
-    for (let i = 0; i < numberOfContentPanes; i++) {
-      contents.push(contentPanesInSlide[i]);
-    }
-
-    const visPanes = visualizations.map((vis: any, index: number) => {
-      return (
-        <ReactResizeDetector key={`vis${index}`} handleWidth handleHeight>
-          {({ width, height, targetRef }) => {
-            return (
-              <StoryVisPane
-                id={vis !== undefined ? vis.id : `vis${index}`}
-                targetRef={targetRef as RefObject<HTMLDivElement>}
-                width={width}
-                height={height}
-                setEditElement={setEditElement}
-                setOpenDialog={setOpenDialog}
-                slide={slide}
-                visualization={vis}
-                increaseNumberOfContentPane={increaseNumberOfContentPanes}
-                dropContent={onDropContentPane}
-              />
-            );
-          }}
-        </ReactResizeDetector>
-      );
-    });
-
-    const contentPanes = contents.map((pane: any, index: number) => {
-      return (
-        <ReactResizeDetector key={`contentPane${index}`} handleWidth handleHeight>
-          {({ width, height, targetRef }) => {
-            return (
-              <StoryContentPane
-                id={pane !== undefined ? pane.id : `contentPane${index}`}
-                contentPane={pane}
-                targetRef={targetRef as RefObject<HTMLDivElement>}
-                width={width}
-                height={height}
-                setEditElement={setEditElement}
-                setOpenDialog={setOpenDialog}
-                slide={slide}
-                onDrop={onDropContentPane}
-              />
-            );
-          }}
-        </ReactResizeDetector>
-      );
-    });
-
-    return (
-      <Allotment vertical={true}>
-        <Allotment.Pane>
-          <Allotment>
-            <Allotment.Pane visible={visPanes.length > 0 ? true : false}>
-              <Allotment
-                key={`alottmentForVis${vertical}`}
-                /* Force the layout to repaint */ vertical={vertical ? false : true}
-              >
-                {visPanes.map((vis, index) => {
-                  return <Allotment.Pane key={index}>{vis}</Allotment.Pane>;
-                })}
-              </Allotment>
-            </Allotment.Pane>
-            <Allotment.Pane preferredSize={'33%'} visible={contentPanes.length > 0 ? true : false}>
-              <Allotment
-                key={`alottmentForContent${vertical}`} //Force the layout to repaint
-                vertical={vertical ? false : true}
-              >
-                {contentPanes.map((content, index) => {
-                  return <Allotment.Pane key={index}>{content}</Allotment.Pane>;
-                })}
-              </Allotment>
-            </Allotment.Pane>
-          </Allotment>
-        </Allotment.Pane>
-        <Allotment.Pane maxSize={50} key={`${timescale}`} visible={timescale}>
-          <div className="h-full w-full bg-intavia-red-200" />
-        </Allotment.Pane>
-      </Allotment>
-    );
-  };
-
   return (
     /* innerref={imageRef} */
     // className={styles['slide-editor-wrapper']}
     <div ref={targetRef} className="h-full">
-      {createSplitterLayout()}
+      {/* {createSplitterLayout()} */}
+      <VisualizationGroup
+        layout={layout}
+        visualizationSlots={slide.visualizationSlots}
+        contentPaneSlots={slide.contentPaneSlots}
+        onAddVisualization={(visSlot: string, visId: string) => {
+          dispatch(
+            setVisualizationForVisualizationSlotForStorySlide({
+              slide: slide,
+              visualizationSlot: visSlot,
+              visualizationId: visId,
+            }),
+          );
+        }}
+        onReleaseVisualization={(visSlot: string) => {
+          dispatch(
+            releaseVisualizationForVisualizationSlotForSlide({
+              slide: slide,
+              visSlot: visSlot,
+            }),
+          );
+        }}
+        onSwitchVisualization={onSwitchVisualization}
+        onAddContentPane={onAddContentPane}
+        onDropContentPane={onDropContentPane}
+        setEditElement={setEditElement}
+        setOpenDialog={setOpenDialog}
+      />
       {editElement != null && (
         <StoryContentDialog
           open={openDialog}

--- a/src/features/storycreator/SlideEditor.tsx
+++ b/src/features/storycreator/SlideEditor.tsx
@@ -24,7 +24,7 @@ interface SlideEditorProps {
   width?: number | undefined;
   height?: number | undefined; // FIXME: unused
   targetRef?: RefObject<HTMLDivElement>;
-  /* imageRef: RefObject<HTMLDivElement>; */
+  imageRef: RefObject<HTMLDivElement>;
   slide: Slide;
   takeScreenshot?: () => void;
   numberOfVisPanes?: number;
@@ -44,12 +44,8 @@ interface DropProps {
 
 export function SlideEditor(props: SlideEditorProps) {
   const {
-    targetRef,
     slide,
-    /* imageRef, */
-    /*  numberOfContentPanes,
-    numberOfVisPanes,
-    vertical = false, */
+    imageRef,
     layout,
     //desktop = false,
   } = props;
@@ -143,7 +139,7 @@ export function SlideEditor(props: SlideEditorProps) {
   return (
     /* innerref={imageRef} */
     // className={styles['slide-editor-wrapper']}
-    <div ref={targetRef} className="h-full">
+    <div ref={imageRef} className="h-full">
       {/* {createSplitterLayout()} */}
       <VisualizationGroup
         layout={layout}

--- a/src/features/storycreator/StoryContentDialog.tsx
+++ b/src/features/storycreator/StoryContentDialog.tsx
@@ -43,68 +43,79 @@ export function StoryContentDialog(props: StoryContentDialogProps): JSX.Element 
     setTmpProperties({ ...tmpProperties, answerlist: newVal });
   };
 
-  const editableAttributes = Object.values(element.properties as object)
-    .filter((prop: StoryContentProperty) => {
-      return prop.editable;
-    })
-    .sort((a: StoryContentProperty, b: StoryContentProperty) => {
-      return a.sort - b.sort;
-    });
+  let editableAttributes = [];
+
+  if (element.properties !== undefined) {
+    editableAttributes = Object.values(element.properties as object)
+      .filter((prop: StoryContentProperty) => {
+        return prop.editable;
+      })
+      .sort((a: StoryContentProperty, b: StoryContentProperty) => {
+        return a.sort - b.sort;
+      });
+  } else {
+    //TODO use real properties of visualization to show values and make them editable
+    editableAttributes = [];
+  }
 
   return (
     <Dialog open={open} onClose={onClose}>
       <DialogTitle>{`Edit ${element.type}`}</DialogTitle>
-      <DialogContent>
-        <form
-          onSubmit={(event) => {
-            event.preventDefault();
-            const newElement = { ...element, properties: tmpProperties };
-            onSave(newElement);
-          }}
-          id="myform"
-        >
-          <FormControl>
-            {editableAttributes.map((property: StoryContentProperty) => {
-              switch (property.type) {
-                case 'text':
-                  return (
-                    <TextField
-                      margin="dense"
-                      id={property.id}
-                      key={property.label}
-                      label={property.label}
-                      fullWidth
-                      variant="standard"
-                      defaultValue={property.value}
-                      sx={{ width: '500px' }}
-                      onChange={onChange}
-                    />
-                  );
-                case 'textarea':
-                  return (
-                    <TextareaAutosize
-                      id={property.id}
-                      key={property.label}
-                      defaultValue={property.value}
-                      placeholder={property.label}
-                      style={{ width: '100%' }}
-                      minRows={3}
-                      onChange={onChange}
-                    />
-                  );
-                case 'answerlist':
-                  return (
-                    <StoryQuizAnswerList
-                      key={property.label}
-                      setAnswerListForQuiz={setAnswerListForQuiz}
-                      answerList={property as StoryAnswerList}
-                    />
-                  );
-              }
-            })}
-          </FormControl>
-        </form>
-      </DialogContent>
+      {editableAttributes.length > 0 ? (
+        <DialogContent>
+          <form
+            onSubmit={(event) => {
+              event.preventDefault();
+              const newElement = { ...element, properties: tmpProperties };
+              onSave(newElement);
+            }}
+            id="myform"
+          >
+            <FormControl>
+              {editableAttributes.map((property: StoryContentProperty) => {
+                switch (property.type) {
+                  case 'text':
+                    return (
+                      <TextField
+                        margin="dense"
+                        id={property.id}
+                        key={property.label}
+                        label={property.label}
+                        fullWidth
+                        variant="standard"
+                        defaultValue={property.value}
+                        sx={{ width: '500px' }}
+                        onChange={onChange}
+                      />
+                    );
+                  case 'textarea':
+                    return (
+                      <TextareaAutosize
+                        id={property.id}
+                        key={property.label}
+                        defaultValue={property.value}
+                        placeholder={property.label}
+                        style={{ width: '100%' }}
+                        minRows={3}
+                        onChange={onChange}
+                      />
+                    );
+                  case 'answerlist':
+                    return (
+                      <StoryQuizAnswerList
+                        key={property.label}
+                        setAnswerListForQuiz={setAnswerListForQuiz}
+                        answerList={property as StoryAnswerList}
+                      />
+                    );
+                }
+              })}
+            </FormControl>
+          </form>
+        </DialogContent>
+      ) : (
+        'Please add properties to the visualization to edit them!'
+      )}
       <DialogActions>
         <Button onClick={onClose}>Cancel</Button>
         <Button type="submit" form="myform" onClick={onClose}>

--- a/src/features/storycreator/StoryContentPane.tsx
+++ b/src/features/storycreator/StoryContentPane.tsx
@@ -1,53 +1,43 @@
 import { CardContent, CardMedia, Typography } from '@mui/material';
 import Card from '@mui/material/Card';
-import type { RefObject } from 'react';
 import ReactGridLayout from 'react-grid-layout';
+import ReactResizeDetector from 'react-resize-detector';
 
-import { useAppDispatch } from '@/app/store';
+import { useAppDispatch, useAppSelector } from '@/app/store';
+import {
+  removeSlideContent,
+  resizeMoveContent,
+  selectContentPaneByID,
+} from '@/features/storycreator/contentPane.slice';
 import styles from '@/features/storycreator/storycreator.module.css';
 import type {
-  ContentPane,
-  Slide,
   SlideContent,
   StoryAnswerList,
   StoryImage,
   StoryQuizAnswer,
 } from '@/features/storycreator/storycreator.slice';
-import { removeSlideContent, resizeMoveContent } from '@/features/storycreator/storycreator.slice';
 import { Window } from '@/features/ui/Window';
 
-const rowHeight = 30;
 const margin: [number, number] = [0, 0];
 
 interface StoryContentPaneProps {
   id: string;
-  width: number | undefined;
-  height: number | undefined;
-  targetRef: RefObject<HTMLElement>;
-  slide: Slide;
-  setEditElement: (arg0: any) => void;
+  setEditElement?: (arg0: any) => void;
   setOpenDialog: (arg0: boolean) => void;
-  contentPane: ContentPane | undefined;
-  onDrop: (i_layout: any, i_layoutItem: any, event: any, targetPane: any) => void;
+  onDrop?: (i_layout: any, i_layoutItem: any, event: any, targetPane: any) => void;
 }
 
 export function StoryContentPane(props: StoryContentPaneProps) {
-  const {
-    id,
-    width: myWidth,
-    /* height, */
-    targetRef,
-    contentPane,
-    slide,
-    setEditElement,
-    setOpenDialog,
-    onDrop,
-  } = props;
+  const { id, setEditElement, setOpenDialog, onDrop } = props;
 
   /* const myHeight =
     height !== undefined ? Math.floor((height + margin[1]) / (rowHeight + margin[1])) : 12; */
 
   const dispatch = useAppDispatch();
+
+  const contentPane = useAppSelector((state) => {
+    return selectContentPaneByID(state, id);
+  });
 
   let contents: Array<SlideContent>;
   if (contentPane !== undefined) {
@@ -59,7 +49,7 @@ export function StoryContentPane(props: StoryContentPaneProps) {
   }
 
   const removeWindowHandler = (element: SlideContent) => {
-    dispatch(removeSlideContent({ slide: slide, parentPane: id, content: element }));
+    dispatch(removeSlideContent({ parentPane: id, content: element }));
   };
 
   const createWindowContent = (element: SlideContent) => {
@@ -188,7 +178,7 @@ export function StoryContentPane(props: StoryContentPaneProps) {
   };
 
   const myDrop = (i_layout: any, i_layoutItem: any, event: any) => {
-    onDrop(i_layout, i_layoutItem, event, id);
+    if (onDrop !== undefined) onDrop(i_layout, i_layoutItem, event, id);
   };
 
   const createLayoutPane = (element: any) => {
@@ -206,8 +196,10 @@ export function StoryContentPane(props: StoryContentPaneProps) {
                 removeWindowHandler(element);
               }}
               onEditContent={() => {
-                setEditElement(element);
-                setOpenDialog(true);
+                if (setEditElement !== undefined) {
+                  setEditElement(element);
+                  setOpenDialog(true);
+                }
               }}
               static={true}
             >
@@ -225,57 +217,56 @@ export function StoryContentPane(props: StoryContentPaneProps) {
   });
 
   return (
-    <div
-      ref={targetRef as RefObject<HTMLDivElement>}
-      className={`${styles['slide-editor-wrapper']} bg-intavia-blue-200`}
-    >
-      <ReactGridLayout
-        className="layout"
-        layout={layout}
-        rowHeight={rowHeight}
-        margin={margin}
-        cols={1}
-        width={myWidth}
-        isDroppable={true}
-        compactType={'vertical'}
-        useCSSTransforms={true}
-        isDraggable={true}
-        style={{
-          width: '100%',
-          height: '100%',
-          overflow: 'hidden',
-          overflowY: 'scroll',
-        }}
-        onDrop={myDrop}
-        onResizeStop={(iLayout, element, resized) => {
-          dispatch(
-            resizeMoveContent({
-              layout: resized,
-              slide: slide.id,
-              story: slide.story,
-              parentPane: id,
-              content: element.i,
-              parentType: 'Content',
-            }),
+    <div className="grid h-full w-full">
+      <ReactResizeDetector handleWidth handleHeight>
+        {({ width, height }) => {
+          return (
+            <ReactGridLayout
+              className="layout"
+              layout={layout}
+              rowHeight={height !== undefined ? height / 8 : 60}
+              margin={margin}
+              cols={1}
+              width={width}
+              isDroppable={true}
+              compactType={'vertical'}
+              useCSSTransforms={true}
+              isDraggable={true}
+              style={{
+                width: '100%',
+                height: '100%',
+                overflow: 'hidden',
+                overflowY: 'scroll',
+              }}
+              onDrop={myDrop}
+              onResizeStop={(iLayout, element, resized) => {
+                dispatch(
+                  resizeMoveContent({
+                    layout: resized,
+                    parentPane: id,
+                    content: element.i,
+                    parentType: 'Content',
+                  }),
+                );
+              }}
+              onDragStop={(iLayout, element, dragged) => {
+                dispatch(
+                  resizeMoveContent({
+                    layout: dragged,
+                    parentPane: id,
+                    content: element.i,
+                    parentType: 'Content',
+                  }),
+                );
+              }}
+            >
+              {contents.map((content) => {
+                return createLayoutPane(content);
+              })}
+            </ReactGridLayout>
           );
         }}
-        onDragStop={(iLayout, element, dragged) => {
-          dispatch(
-            resizeMoveContent({
-              layout: dragged,
-              slide: slide.id,
-              story: slide.story,
-              parentPane: id,
-              content: element.i,
-              parentType: 'Content',
-            }),
-          );
-        }}
-      >
-        {contents.map((content) => {
-          return createLayoutPane(content);
-        })}
-      </ReactGridLayout>
+      </ReactResizeDetector>
     </div>
   );
 }

--- a/src/features/storycreator/StoryContentPane.tsx
+++ b/src/features/storycreator/StoryContentPane.tsx
@@ -227,8 +227,7 @@ export function StoryContentPane(props: StoryContentPaneProps) {
   return (
     <div
       ref={targetRef as RefObject<HTMLDivElement>}
-      className={styles['slide-editor-wrapper']}
-      style={{ backgroundColor: 'lightblue' }}
+      className={`${styles['slide-editor-wrapper']} bg-intavia-blue-200`}
     >
       <ReactGridLayout
         className="layout"

--- a/src/features/storycreator/StoryContentPane.tsx
+++ b/src/features/storycreator/StoryContentPane.tsx
@@ -1,3 +1,5 @@
+import { AdjustmentsIcon } from '@heroicons/react/outline';
+import { XIcon } from '@heroicons/react/solid';
 import { CardContent, CardMedia, Typography } from '@mui/material';
 import Card from '@mui/material/Card';
 import ReactGridLayout from 'react-grid-layout';
@@ -16,7 +18,7 @@ import type {
   StoryImage,
   StoryQuizAnswer,
 } from '@/features/storycreator/storycreator.slice';
-import { Window } from '@/features/ui/Window';
+import Button from '@/features/ui/Button';
 
 const margin: [number, number] = [0, 0];
 
@@ -188,23 +190,37 @@ export function StoryContentPane(props: StoryContentPaneProps) {
       case 'Quiz':
         return (
           <div key={element.id} className={styles.elevated}>
-            <Window
-              className={styles['annotation-window']}
-              title={element.type}
-              id={element.id}
-              onRemoveWindow={() => {
-                removeWindowHandler(element);
-              }}
-              onEditContent={() => {
-                if (setEditElement !== undefined) {
-                  setEditElement(element);
-                  setOpenDialog(true);
-                }
-              }}
-              static={true}
-            >
-              {createWindowContent(element)}
-            </Window>
+            <div className="flex flex-row flex-nowrap justify-between gap-2 truncate bg-indigo-800 px-2 py-1 text-white">
+              <div className="truncate">{element.type}</div>
+              <div className="sticky right-0 flex flex-nowrap gap-1">
+                <Button
+                  className="ml-auto grow-0"
+                  shadow="none"
+                  size="extra-small"
+                  round="circle"
+                  onClick={() => {
+                    if (setEditElement !== undefined) {
+                      setEditElement(element);
+                      setOpenDialog(true);
+                    }
+                  }}
+                >
+                  <AdjustmentsIcon className="h-3 w-3" />
+                </Button>
+                <Button
+                  className="ml-auto grow-0"
+                  shadow="none"
+                  size="extra-small"
+                  round="circle"
+                  onClick={() => {
+                    removeWindowHandler(element);
+                  }}
+                >
+                  <XIcon className="h-3 w-3" />
+                </Button>
+              </div>
+            </div>
+            {createWindowContent(element)}
           </div>
         );
       default:

--- a/src/features/storycreator/StoryFlow.tsx
+++ b/src/features/storycreator/StoryFlow.tsx
@@ -7,17 +7,17 @@ import styles from '@/features/storycreator/storycreator.module.css';
 import type { Slide, Story } from '@/features/storycreator/storycreator.slice';
 import { copySlide, removeSlide, selectSlide } from '@/features/storycreator/storycreator.slice';
 import { Window } from '@/features/ui/Window';
-
 // FIXME: height unused
 interface StoryFlowProps {
   width: number | undefined;
   height: number | undefined;
   targetRef: RefObject<HTMLElement> | undefined;
   story: Story;
+  vertical?: boolean;
 }
 
 export function StoryFlow(props: StoryFlowProps) {
-  const { width: myWidth, targetRef, story } = props;
+  const { story, vertical = false, width, height, targetRef } = props;
 
   const dispatch = useAppDispatch();
 
@@ -36,11 +36,15 @@ export function StoryFlow(props: StoryFlowProps) {
     for (const i in newSlides) {
       const s = newSlides[parseInt(i)]!;
       newLayout.push({ i: 'slide' + s.id, x: x, y: y, w: 1, h: 1 });
-      x = x + 1;
 
-      if ((parseInt(i) + 1) % 8 === 0) {
-        x = 0;
+      if (vertical) {
         y = y + 1;
+      } else {
+        x = x + 1;
+        if ((parseInt(i) + 1) % 8 === 0) {
+          x = 0;
+          y = y + 1;
+        }
       }
     }
 
@@ -58,22 +62,24 @@ export function StoryFlow(props: StoryFlowProps) {
   function onCopy(slideID: Slide['id']) {
     dispatch(copySlide({ story: story.id, slide: slideID }));
   }
+  console.log('height', height);
 
   return (
     <div
-      ref={targetRef as RefObject<HTMLDivElement>}
-      className={styles['slide-editor-wrapper']}
-      style={{ overflow: 'hidden', overflowY: 'scroll' }}
+    /* className={styles['slide-editor-wrapper']} */
+    /* ref={targetRef as RefObject<HTMLDivElement>} */
     >
       <ReactGridLayout
+        innerRef={targetRef as RefObject<HTMLDivElement>}
         className="layout"
         layout={layout}
         rowHeight={120}
-        cols={8}
-        width={myWidth}
-        compactType="horizontal"
+        width={width}
+        cols={vertical ? 1 : 8}
+        compactType={vertical ? 'vertical' : 'horizontal'}
         isResizable={false}
         useCSSTransforms={true}
+        style={{ height: `${height}px`, maxHeight: `${height}px` }}
       >
         {slides.map((slide: Slide) => {
           return (

--- a/src/features/storycreator/StoryFlow.tsx
+++ b/src/features/storycreator/StoryFlow.tsx
@@ -62,7 +62,6 @@ export function StoryFlow(props: StoryFlowProps) {
   function onCopy(slideID: Slide['id']) {
     dispatch(copySlide({ story: story.id, slide: slideID }));
   }
-  console.log('height', height);
 
   return (
     <div

--- a/src/features/storycreator/StoryGUICreator.tsx
+++ b/src/features/storycreator/StoryGUICreator.tsx
@@ -3,23 +3,18 @@ import '~/node_modules/react-resizable/css/styles.css';
 
 import { Button, IconButton } from '@mui/material';
 import { Allotment } from 'allotment';
-import { toPng } from 'html-to-image';
-import type { RefObject } from 'react';
-import { useRef } from 'react';
 import ReactResizeDetector from 'react-resize-detector';
 
 import { useAppDispatch, useAppSelector } from '@/app/store';
 import { selectEntitiesByKind } from '@/features/common/entities.slice';
 import type { Place } from '@/features/common/entity.model';
 import { DroppableIcon } from '@/features/storycreator/DroppableIcon';
-import { SlideEditor } from '@/features/storycreator/SlideEditor';
 import styles from '@/features/storycreator/storycreator.module.css';
 import type { Slide, Story } from '@/features/storycreator/storycreator.slice';
 import {
   createSlide,
   createSlidesInBulk,
   selectSlidesByStoryID,
-  setImage,
   setLayoutForSlide,
 } from '@/features/storycreator/storycreator.slice';
 import { StoryFlow } from '@/features/storycreator/StoryFlow';
@@ -32,50 +27,6 @@ interface DropProps {
   place?: Place | null;
   date?: IsoDateString;
 }
-
-interface SlideLayout {
-  numberOfVis: 0 | 1 | 2;
-  numberOfContentPanes: 0 | 1 | 2;
-  vertical: boolean;
-}
-
-const SlideLayouts: Record<string, SlideLayout> = {
-  singlevis: {
-    numberOfVis: 1,
-    numberOfContentPanes: 0,
-    vertical: false,
-  },
-  twovisvertical: {
-    numberOfVis: 2,
-    numberOfContentPanes: 0,
-    vertical: true,
-  },
-  twovishorizontal: {
-    numberOfVis: 2,
-    numberOfContentPanes: 0,
-    vertical: false,
-  },
-  singleviscontent: {
-    numberOfVis: 1,
-    numberOfContentPanes: 1,
-    vertical: false,
-  },
-  twoviscontenthorizontal: {
-    numberOfVis: 2,
-    numberOfContentPanes: 1,
-    vertical: false,
-  },
-  twoviscontentvertical: {
-    numberOfVis: 2,
-    numberOfContentPanes: 1,
-    vertical: true,
-  },
-  twocontents: {
-    numberOfVis: 0,
-    numberOfContentPanes: 2,
-    vertical: true,
-  },
-};
 
 const createDrops = (props: DropProps) => {
   const { type } = props;
@@ -178,9 +129,8 @@ export function StoryGUICreator(props: StoryGUICreatorProps): JSX.Element {
   });
   const selectedSlide = filteredSlides.length > 0 ? filteredSlides[0] : slides[0];
 
-  const ref = useRef<HTMLDivElement>(null);
-
-  const takeScreenshot = function () {
+  /*  const ref = useRef<HTMLDivElement>(null);
+     const takeScreenshot = function () {
     if (ref.current === null) {
       return;
     }
@@ -192,7 +142,7 @@ export function StoryGUICreator(props: StoryGUICreatorProps): JSX.Element {
       .catch((err) => {
         console.log(err);
       });
-  };
+  }; */
 
   const entitiesByKind = useAppSelector(selectEntitiesByKind);
   const persons = Object.values(entitiesByKind.person).slice(-1);
@@ -243,11 +193,11 @@ export function StoryGUICreator(props: StoryGUICreatorProps): JSX.Element {
     dispatch(setLayoutForSlide({ slide: selectedSlide, layout: i_layout }));
   };
 
-  const { numberOfVis, numberOfContentPanes, vertical } = SlideLayouts[
+  /*const { numberOfVis, numberOfContentPanes, vertical } = SlideLayouts[
     selectedSlide!.layout
   ] as SlideLayout;
 
-  const increaseNumberOfContentPanes = () => {
+   const increaseNumberOfContentPanes = () => {
     if (numberOfContentPanes === 0) {
       for (const key of Object.keys(SlideLayouts)) {
         const layout = SlideLayouts[key];
@@ -260,7 +210,7 @@ export function StoryGUICreator(props: StoryGUICreatorProps): JSX.Element {
         }
       }
     }
-  };
+  }; */
 
   return (
     <div style={{ position: 'relative', height: `100%`, width: `100%` }}>
@@ -402,14 +352,13 @@ export function StoryGUICreator(props: StoryGUICreatorProps): JSX.Element {
             </Allotment.Pane>
             <Allotment.Pane preferredSize="60%">
               <ReactResizeDetector handleWidth handleHeight>
-                {({ width, height, targetRef }) => {
+                {() => {
                   return (
-                    <SlideEditor
+                    /*  <SlideEditor
                       targetRef={targetRef as RefObject<HTMLDivElement>}
                       width={width}
                       height={height}
                       slide={selectedSlide as Slide}
-                      /* imageRef={ref} */
                       takeScreenshot={takeScreenshot}
                       numberOfVisPanes={numberOfVis}
                       numberOfContentPanes={numberOfContentPanes}
@@ -417,7 +366,8 @@ export function StoryGUICreator(props: StoryGUICreatorProps): JSX.Element {
                       timescale={false}
                       desktop={true}
                       increaseNumberOfContentPanes={increaseNumberOfContentPanes}
-                    />
+                    /> */
+                    <></>
                   );
                 }}
               </ReactResizeDetector>

--- a/src/features/storycreator/StoryGUICreator.tsx
+++ b/src/features/storycreator/StoryGUICreator.tsx
@@ -414,6 +414,8 @@ export function StoryGUICreator(props: StoryGUICreatorProps): JSX.Element {
                       numberOfVisPanes={numberOfVis}
                       numberOfContentPanes={numberOfContentPanes}
                       vertical={vertical}
+                      timescale={false}
+                      desktop={true}
                       increaseNumberOfContentPanes={increaseNumberOfContentPanes}
                     />
                   );

--- a/src/features/storycreator/StoryMap.tsx
+++ b/src/features/storycreator/StoryMap.tsx
@@ -6,14 +6,14 @@ import Link from 'next/link';
 import { useEffect, useRef } from 'react';
 import type { MapRef } from 'react-map-gl';
 
-import type { StoryEvent } from '@/features/common/entity.model';
+import type { EntityEvent, StoryEvent } from '@/features/common/entity.model';
 import { GeoMap } from '@/features/geomap/geo-map';
 import { base as baseMap } from '@/features/geomap/maps.config';
 import { StoryMapPin } from '@/features/storycreator/StoryMapPin';
 import { length } from '@/lib/length';
 
 interface StoryMapProps {
-  events: Array<StoryEvent>;
+  events: Array<EntityEvent | StoryEvent>;
   width?: number;
   height?: number;
   setMapBounds?: (bounds: Array<Array<number>>) => void;

--- a/src/features/storycreator/StoryVisPane.tsx
+++ b/src/features/storycreator/StoryVisPane.tsx
@@ -3,7 +3,8 @@ import { useEffect } from 'react';
 import ReactGridLayout from 'react-grid-layout';
 
 import { useAppDispatch, useAppSelector } from '@/app/store';
-import type { Person, StoryEvent } from '@/features/common/entity.model';
+import type { EntityEvent, Person, StoryEvent } from '@/features/common/entity.model';
+import { StoryTimeline } from '@/features/storycreator/story-timeline';
 import styles from '@/features/storycreator/storycreator.module.css';
 import type {
   Slide,
@@ -72,7 +73,7 @@ export function StoryVisPane(props: StoryVisPaneProps) {
   }
 
   useEffect(() => {
-    console.log('vis changed');
+    console.log('Updated Visualization');
   }, [visualization]);
 
   const removeWindowHandler = (element: SlideContent) => {
@@ -89,7 +90,10 @@ export function StoryVisPane(props: StoryVisPaneProps) {
     } else if (dropProps.type === 'Person') {
       const person = dropProps.props as Person;
       if (person.history !== undefined) {
-        dispatch(addEventsToVisPane({ slide: slide, visPane: id, events: [...person.history] }));
+        const newHistory = person.history.map((historyEvent: EntityEvent) => {
+          return { ...historyEvent, targetId: person.id.toString() } as EntityEvent;
+        });
+        dispatch(addEventsToVisPane({ slide: slide, visPane: id, events: [...newHistory] }));
       }
     } else {
       const ids = windows.map((window: UiWindow) => {
@@ -108,9 +112,6 @@ export function StoryVisPane(props: StoryVisPaneProps) {
 
       switch (dropProps.type) {
         case 'Timeline':
-          layoutItem['h'] = 12;
-          layoutItem['w'] = 3;
-          break;
         case 'Map':
           layoutItem['h'] = myHeight;
           layoutItem['w'] = 48;
@@ -159,8 +160,7 @@ export function StoryVisPane(props: StoryVisPaneProps) {
   const createWindowContent = (element: SlideContent) => {
     switch (element.type) {
       case 'Timeline':
-        //return <TimelineExample data={[]} />;
-        return [];
+        return <StoryTimeline events={events} />;
       case 'Map':
         return (
           <StoryMapComponent
@@ -181,6 +181,7 @@ export function StoryVisPane(props: StoryVisPaneProps) {
 
   const createLayoutPane = (element: any) => {
     switch (element.type) {
+      case 'Timeline':
       case 'Map':
         return (
           <div key={element.id} className={styles.elevated}>

--- a/src/features/storycreator/StoryVisPane.tsx
+++ b/src/features/storycreator/StoryVisPane.tsx
@@ -1,4 +1,4 @@
-import type { RefObject } from 'react';
+/* import type { RefObject } from 'react';
 import { useEffect } from 'react';
 import ReactGridLayout from 'react-grid-layout';
 
@@ -12,14 +12,7 @@ import type {
   StoryMap,
   VisualisationPane,
 } from '@/features/storycreator/storycreator.slice';
-import {
-  addEventsToVisPane,
-  addEventToVisPane,
-  addVisualization,
-  editSlideContent,
-  removeSlideContent,
-  resizeMoveContent,
-} from '@/features/storycreator/storycreator.slice';
+import { addVisualization } from '@/features/storycreator/storycreator.slice';
 import { StoryMapComponent } from '@/features/storycreator/StoryMap';
 import type { UiWindow } from '@/features/ui/ui.slice';
 import { selectWindows } from '@/features/ui/ui.slice';
@@ -77,7 +70,6 @@ export function StoryVisPane(props: StoryVisPaneProps) {
   }, [visualization]);
 
   const removeWindowHandler = (element: SlideContent) => {
-    //dispatch(removeContent({ id: id, story: slide.story, slide: slide.id }));
     dispatch(removeSlideContent({ slide: slide, parentPane: id, content: element }));
   };
 
@@ -160,7 +152,7 @@ export function StoryVisPane(props: StoryVisPaneProps) {
   const createWindowContent = (element: SlideContent) => {
     switch (element.type) {
       case 'Timeline':
-        return <StoryTimeline events={events} />;
+        return <StoryTimeline events={events} persons={[]} />;
       case 'Map':
         return (
           <StoryMapComponent
@@ -263,4 +255,9 @@ export function StoryVisPane(props: StoryVisPaneProps) {
       </ReactGridLayout>
     </div>
   );
+}
+ */
+
+export function StoryVisPane() {
+  return <></>;
 }

--- a/src/features/storycreator/contentPane.slice.ts
+++ b/src/features/storycreator/contentPane.slice.ts
@@ -1,0 +1,152 @@
+import { createSelector, createSlice } from '@reduxjs/toolkit';
+
+import type { RootState } from '@/app/store';
+import type { StoryContentProperty } from '@/features/storycreator/storycreator.slice';
+import {
+  StoryImageObject,
+  StoryQuizObject,
+  StoryTextObject,
+} from '@/features/storycreator/storycreator.slice';
+
+export type ContentSlotId = 'cont-1' | 'cont-2';
+
+export interface StoryMapMarker {
+  position: [number, number];
+  type: string;
+}
+
+export interface SlideContent {
+  id: string;
+  parentPane: string;
+  type: 'Image' | 'Map' | 'Quiz' | 'Text' | 'Timeline';
+  layout: {
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+  };
+  properties?: Record<StoryContentProperty['id'], StoryContentProperty>;
+}
+
+export interface ContentPane {
+  id: string;
+  contents: Record<SlideContent['id'], SlideContent>;
+}
+
+const initialState: Record<ContentPane['id'], ContentPane> = {};
+
+export const contentPaneSlice = createSlice({
+  name: 'contentPane',
+  initialState,
+  reducers: {
+    createContentPane: (state, action) => {
+      const id = action.payload.id;
+      state[id] = { id: id, contents: {} } as ContentPane;
+    },
+    addContentToContentPane: (state, action) => {
+      const content = action.payload;
+
+      const contentPaneID = content.contentPane;
+      const contentPane = state[contentPaneID];
+      //const contentId = `content${Object.keys(contentPane?.contents).length}`;
+
+      const contents = contentPane?.contents;
+      const oldIDs = Object.keys(contents as object);
+
+      let counter = 0;
+      let newID;
+      do {
+        counter = counter + 1;
+        newID = `${content.slide}(${counter})`;
+      } while (oldIDs.includes(newID));
+
+      content.id = newID;
+
+      let contentObject;
+      switch (content.type) {
+        case 'Image':
+          contentObject = new StoryImageObject(content.id, content.contentPane, content.layout);
+          break;
+        case 'Text':
+          contentObject = new StoryTextObject(content.id, content.contentPane, content.layout);
+          break;
+        case 'Quiz':
+          contentObject = new StoryQuizObject(content.id, content.contentPane, content.layout);
+          break;
+        default:
+          break;
+      }
+
+      if (contentObject !== undefined) {
+        state[contentPaneID]!.contents[newID] = contentObject;
+      }
+    },
+    resizeMoveContent: (state, action) => {
+      const layout = action.payload.layout;
+      const content = action.payload.content;
+      const parentPane = action.payload.parentPane;
+      const type = action.payload.parentType;
+      let objectToChange;
+
+      if (type === 'Content') {
+        objectToChange = state[parentPane]!.contents[content];
+        if (objectToChange !== undefined) {
+          objectToChange.layout = {
+            x: layout.x,
+            y: layout.y,
+            w: layout.w,
+            h: layout.h,
+          };
+        }
+      }
+    },
+    editSlideContent: (state, action) => {
+      const content = action.payload.content;
+
+      switch (content.type) {
+        case 'Text':
+        case 'Image':
+        case 'Quiz':
+          state[content.parentPane]!.contents[content.id] = content;
+          break;
+      }
+    },
+    removeSlideContent: (state, action) => {
+      const content = action.payload.content;
+
+      switch (content.type) {
+        case 'Text':
+        case 'Image':
+        case 'Quiz':
+          delete state[content.parentPane]!.contents[content.id];
+          break;
+      }
+    },
+  },
+});
+
+export const {
+  createContentPane,
+  addContentToContentPane,
+  resizeMoveContent,
+  editSlideContent,
+  removeSlideContent,
+} = contentPaneSlice.actions;
+
+export const selectContentPaneByID = createSelector(
+  (state: RootState) => {
+    return state.contentPane;
+  },
+  (state: RootState, id: string) => {
+    return id;
+  },
+  (contentPanes, id) => {
+    return contentPanes[id];
+  },
+);
+
+/* export const selectStories = (state: RootState) => {
+  return state.storycreator.stories;
+}; */
+
+export default contentPaneSlice.reducer;

--- a/src/features/storycreator/slide-layout-popover.tsx
+++ b/src/features/storycreator/slide-layout-popover.tsx
@@ -1,0 +1,176 @@
+import type { SlideLayout } from '@/features/storycreator/story-center-pane';
+import Button from '@/features/ui/Button';
+import Popover from '@/features/ui/Popover';
+
+interface LayoutOptionData {
+  key: string;
+  symbol?: string;
+  title: string;
+  description?: string;
+  contentSymbol?: string;
+  layout: SlideLayout;
+}
+
+const SlideLayouts: Record<string, SlideLayout> = {
+  singlevis: {
+    numberOfVis: 1,
+    numberOfContentPanes: 0,
+    vertical: false,
+  },
+  twovisvertical: {
+    numberOfVis: 2,
+    numberOfContentPanes: 0,
+    vertical: true,
+  },
+  twovishorizontal: {
+    numberOfVis: 2,
+    numberOfContentPanes: 0,
+    vertical: false,
+  },
+  singleviscontent: {
+    numberOfVis: 1,
+    numberOfContentPanes: 1,
+    vertical: false,
+  },
+  twoviscontenthorizontal: {
+    numberOfVis: 2,
+    numberOfContentPanes: 1,
+    vertical: false,
+  },
+  twoviscontentvertical: {
+    numberOfVis: 2,
+    numberOfContentPanes: 1,
+    vertical: true,
+  },
+  twocontents: {
+    numberOfVis: 0,
+    numberOfContentPanes: 2,
+    vertical: true,
+  },
+};
+
+const layoutOptions: Array<LayoutOptionData> = [
+  {
+    key: 'singlevis',
+    symbol: 'M0 0H1V1H0z',
+    title: 'Single Vis',
+    description: 'Show only one visualization, in full size.',
+    layout: SlideLayouts.singlevis as SlideLayout,
+  },
+  {
+    key: 'singleviscontent',
+    symbol: 'M0 0H.67V1H0z',
+    contentSymbol: 'M.67 0H1V1H.67Z',
+    title: 'Vis + Content',
+    description: 'Two visualizations, placed next to each other.',
+    layout: SlideLayouts.twovisvertical as SlideLayout,
+  },
+  {
+    key: 'twovishorizontal',
+    symbol: 'M0 0H1V0.5H0z M0 0.5H1V1H0z',
+    title: 'Two Vis',
+    description: 'Two vis, stacked on top of each other.',
+    layout: SlideLayouts.twovishorizontal as SlideLayout,
+  },
+  {
+    key: 'twovisvertical',
+    symbol: 'M0 0H1V1H0zM0.5 0V1',
+    title: 'Two Columns',
+    description: 'Two visualizations, placed next to each other.',
+    layout: SlideLayouts.twovisvertical as SlideLayout,
+  },
+
+  {
+    key: 'twoviscontentvertical',
+    symbol: 'M0 0H.67V1H0zM.33 0V1M.67 0V1Z',
+    contentSymbol: 'M.67 0H1V1H.67Z',
+    title: 'Three Columns',
+    description: 'Two vis left, one content pane right.',
+    layout: SlideLayouts.twoviscontentvertical as SlideLayout,
+  },
+  {
+    key: 'twoviscontenthorizontal',
+    symbol: 'M0 0H.67V1H0zM0 .5H.67M.67 0V1Z',
+    contentSymbol: 'M.67 0H1V1H.67Z',
+    title: 'Two Vis + Content',
+    description: 'Two vis left, one content pane right.',
+    layout: SlideLayouts.twoviscontenthorizontal as SlideLayout,
+  },
+  {
+    key: 'twocontents',
+    contentSymbol: 'M0 0H1V1H0zM0.5 0V1',
+    title: 'Two Contents',
+    description: 'Two content panes, placed next to each other.',
+    layout: SlideLayouts.twovisvertical as SlideLayout,
+  },
+];
+
+export interface SlideLayoutButtonProps {
+  onLayoutSelected: (layoutKey: LayoutOptionData['key']) => void;
+}
+
+export default function SlideLayoutButton(props: SlideLayoutButtonProps): JSX.Element {
+  return (
+    <Popover color="accent" size="small" round="pill">
+      Slide Layout
+      {({ close }) => {
+        return (
+          <div className="w-90">
+            <h3 className="text-lg font-semibold text-intavia-gray-800">Set Your Slide Layout</h3>
+            <div className="max-h-54 grid grid-cols-2 gap-1 overflow-y-auto rounded-md p-1 text-gray-800 drop-shadow-2xl">
+              {layoutOptions.map((option) => {
+                return (
+                  <button
+                    key={option.key}
+                    className="grid grid-cols-[3.6rem_1fr] grid-rows-[1.2rem_2.4rem] gap-1 rounded bg-white p-1 hover:bg-slate-100 active:bg-slate-300"
+                    onClick={() => {
+                      props.onLayoutSelected(option.key);
+                      close();
+                    }}
+                  >
+                    <svg className="col-1 row-span-full" viewBox="-0.3 -0.3 1.6 1.6">
+                      {option.symbol !== undefined && (
+                        <path
+                          d={option.symbol}
+                          strokeWidth={0.02}
+                          shapeRendering="crispEdges"
+                          fill="none"
+                          stroke="currentColor"
+                        />
+                      )}
+                      {option.contentSymbol !== undefined && (
+                        <path
+                          d={option.contentSymbol}
+                          strokeWidth={0.02}
+                          shapeRendering="crispEdges"
+                          fill="rgb(165, 223, 252)"
+                          stroke="currentColor"
+                        />
+                      )}
+                    </svg>
+                    <span className="col-2 row-1 text-left font-semibold">{option.title}</span>
+                    <p className="col-2 row-1 text-left font-light">{option.description ?? ''}</p>
+                  </button>
+                );
+              })}
+            </div>
+
+            <div className="mt-2 flex">
+              <Button
+                size="small"
+                color="warning"
+                round="round"
+                onClick={() => {
+                  return close();
+                }}
+                className="ml-auto self-end"
+              >
+                Close
+              </Button>
+            </div>
+          </div>
+        );
+      }}
+    </Popover>
+  );
+}

--- a/src/features/storycreator/slide-layout-popover.tsx
+++ b/src/features/storycreator/slide-layout-popover.tsx
@@ -1,112 +1,14 @@
-import type { SlideLayout } from '@/features/storycreator/story-center-pane';
+import type {
+  PanelLayout,
+  StoryLayout,
+  StoryVisOptionData,
+} from '@/features/ui/analyse-page-toolbar/layout-popover';
+import { layoutOptions, storyLayout } from '@/features/ui/analyse-page-toolbar/layout-popover';
 import Button from '@/features/ui/Button';
 import Popover from '@/features/ui/Popover';
 
-interface LayoutOptionData {
-  key: string;
-  symbol?: string;
-  title: string;
-  description?: string;
-  contentSymbol?: string;
-  layout: SlideLayout;
-}
-
-const SlideLayouts: Record<string, SlideLayout> = {
-  singlevis: {
-    numberOfVis: 1,
-    numberOfContentPanes: 0,
-    vertical: false,
-  },
-  twovisvertical: {
-    numberOfVis: 2,
-    numberOfContentPanes: 0,
-    vertical: true,
-  },
-  twovishorizontal: {
-    numberOfVis: 2,
-    numberOfContentPanes: 0,
-    vertical: false,
-  },
-  singleviscontent: {
-    numberOfVis: 1,
-    numberOfContentPanes: 1,
-    vertical: false,
-  },
-  twoviscontenthorizontal: {
-    numberOfVis: 2,
-    numberOfContentPanes: 1,
-    vertical: false,
-  },
-  twoviscontentvertical: {
-    numberOfVis: 2,
-    numberOfContentPanes: 1,
-    vertical: true,
-  },
-  twocontents: {
-    numberOfVis: 0,
-    numberOfContentPanes: 2,
-    vertical: true,
-  },
-};
-
-const layoutOptions: Array<LayoutOptionData> = [
-  {
-    key: 'singlevis',
-    symbol: 'M0 0H1V1H0z',
-    title: 'Single Vis',
-    description: 'Show only one visualization, in full size.',
-    layout: SlideLayouts.singlevis as SlideLayout,
-  },
-  {
-    key: 'singleviscontent',
-    symbol: 'M0 0H.67V1H0z',
-    contentSymbol: 'M.67 0H1V1H.67Z',
-    title: 'Vis + Content',
-    description: 'Two visualizations, placed next to each other.',
-    layout: SlideLayouts.twovisvertical as SlideLayout,
-  },
-  {
-    key: 'twovishorizontal',
-    symbol: 'M0 0H1V0.5H0z M0 0.5H1V1H0z',
-    title: 'Two Vis',
-    description: 'Two vis, stacked on top of each other.',
-    layout: SlideLayouts.twovishorizontal as SlideLayout,
-  },
-  {
-    key: 'twovisvertical',
-    symbol: 'M0 0H1V1H0zM0.5 0V1',
-    title: 'Two Columns',
-    description: 'Two visualizations, placed next to each other.',
-    layout: SlideLayouts.twovisvertical as SlideLayout,
-  },
-
-  {
-    key: 'twoviscontentvertical',
-    symbol: 'M0 0H.67V1H0zM.33 0V1M.67 0V1Z',
-    contentSymbol: 'M.67 0H1V1H.67Z',
-    title: 'Three Columns',
-    description: 'Two vis left, one content pane right.',
-    layout: SlideLayouts.twoviscontentvertical as SlideLayout,
-  },
-  {
-    key: 'twoviscontenthorizontal',
-    symbol: 'M0 0H.67V1H0zM0 .5H.67M.67 0V1Z',
-    contentSymbol: 'M.67 0H1V1H.67Z',
-    title: 'Two Vis + Content',
-    description: 'Two vis left, one content pane right.',
-    layout: SlideLayouts.twoviscontenthorizontal as SlideLayout,
-  },
-  {
-    key: 'twocontents',
-    contentSymbol: 'M0 0H1V1H0zM0.5 0V1',
-    title: 'Two Contents',
-    description: 'Two content panes, placed next to each other.',
-    layout: SlideLayouts.twovisvertical as SlideLayout,
-  },
-];
-
 export interface SlideLayoutButtonProps {
-  onLayoutSelected: (layoutKey: LayoutOptionData['key']) => void;
+  onLayoutSelected: (layoutKey: PanelLayout) => void;
 }
 
 export default function SlideLayoutButton(props: SlideLayoutButtonProps): JSX.Element {
@@ -118,29 +20,30 @@ export default function SlideLayoutButton(props: SlideLayoutButtonProps): JSX.El
           <div className="w-90">
             <h3 className="text-lg font-semibold text-intavia-gray-800">Set Your Slide Layout</h3>
             <div className="max-h-54 grid grid-cols-2 gap-1 overflow-y-auto rounded-md p-1 text-gray-800 drop-shadow-2xl">
-              {layoutOptions.map((option) => {
+              {storyLayout.map((option: StoryLayout) => {
+                const layout = layoutOptions[option] as StoryVisOptionData;
                 return (
                   <button
-                    key={option.key}
+                    key={option}
                     className="grid grid-cols-[3.6rem_1fr] grid-rows-[1.2rem_2.4rem] gap-1 rounded bg-white p-1 hover:bg-slate-100 active:bg-slate-300"
                     onClick={() => {
-                      props.onLayoutSelected(option.key);
+                      props.onLayoutSelected(option);
                       close();
                     }}
                   >
                     <svg className="col-1 row-span-full" viewBox="-0.3 -0.3 1.6 1.6">
-                      {option.symbol !== undefined && (
+                      {layout.symbol !== undefined && (
                         <path
-                          d={option.symbol}
+                          d={layout.symbol}
                           strokeWidth={0.02}
                           shapeRendering="crispEdges"
                           fill="none"
                           stroke="currentColor"
                         />
                       )}
-                      {option.contentSymbol !== undefined && (
+                      {layout.contentSymbol !== undefined && (
                         <path
-                          d={option.contentSymbol}
+                          d={layout.contentSymbol}
                           strokeWidth={0.02}
                           shapeRendering="crispEdges"
                           fill="rgb(165, 223, 252)"
@@ -148,8 +51,8 @@ export default function SlideLayoutButton(props: SlideLayoutButtonProps): JSX.El
                         />
                       )}
                     </svg>
-                    <span className="col-2 row-1 text-left font-semibold">{option.title}</span>
-                    <p className="col-2 row-1 text-left font-light">{option.description ?? ''}</p>
+                    <span className="col-2 row-1 text-left font-semibold">{layout.title}</span>
+                    <p className="col-2 row-1 text-left font-light">{layout.description ?? ''}</p>
                   </button>
                 );
               })}

--- a/src/features/storycreator/story-center-pane.tsx
+++ b/src/features/storycreator/story-center-pane.tsx
@@ -1,0 +1,187 @@
+import '~/node_modules/react-grid-layout/css/styles.css';
+import '~/node_modules/react-resizable/css/styles.css';
+
+import { toPng } from 'html-to-image';
+import { useRef } from 'react';
+import ReactResizeDetector from 'react-resize-detector';
+
+import { useAppDispatch, useAppSelector } from '@/app/store';
+import { SlideEditor } from '@/features/storycreator/SlideEditor';
+import StroyCreatorToolbar from '@/features/storycreator/story-creator-toolbar';
+import type { Slide, Story } from '@/features/storycreator/storycreator.slice';
+import {
+  selectSlidesByStoryID,
+  setImage,
+  setLayoutForSlide,
+} from '@/features/storycreator/storycreator.slice';
+
+/* interface DropProps {
+  name?: string | null;
+  title?: string | null;
+  label?: string | null;
+  type: string;
+  place?: Place | null;
+  date?: IsoDateString;
+} */
+
+export interface SlideLayout {
+  numberOfVis: 0 | 1 | 2;
+  numberOfContentPanes: 0 | 1 | 2;
+  vertical: boolean;
+}
+
+export const SlideLayouts: Record<string, SlideLayout> = {
+  singlevis: {
+    numberOfVis: 1,
+    numberOfContentPanes: 0,
+    vertical: false,
+  },
+  twovisvertical: {
+    numberOfVis: 2,
+    numberOfContentPanes: 0,
+    vertical: true,
+  },
+  twovishorizontal: {
+    numberOfVis: 2,
+    numberOfContentPanes: 0,
+    vertical: false,
+  },
+  singleviscontent: {
+    numberOfVis: 1,
+    numberOfContentPanes: 1,
+    vertical: false,
+  },
+  twoviscontenthorizontal: {
+    numberOfVis: 2,
+    numberOfContentPanes: 1,
+    vertical: false,
+  },
+  twoviscontentvertical: {
+    numberOfVis: 2,
+    numberOfContentPanes: 1,
+    vertical: true,
+  },
+  twocontents: {
+    numberOfVis: 0,
+    numberOfContentPanes: 2,
+    vertical: true,
+  },
+};
+
+interface StoryCenterPaneProps {
+  story: Story;
+  desktop: boolean;
+  onDesktopChange: (desktop: boolean) => void;
+  timescale: boolean;
+  onTimescaleChange: (timescale: boolean) => void;
+}
+
+export function StoryCenterPane(props: StoryCenterPaneProps): JSX.Element {
+  const { story, desktop, onDesktopChange, timescale, onTimescaleChange } = props;
+
+  const dispatch = useAppDispatch();
+
+  const slides = useAppSelector((state) => {
+    return selectSlidesByStoryID(state, story.id);
+  });
+
+  const filteredSlides = slides.filter((slide: Slide) => {
+    return slide.selected;
+  });
+  const selectedSlide = filteredSlides.length > 0 ? filteredSlides[0] : slides[0];
+
+  const ref = useRef<HTMLDivElement>(null);
+
+  const takeScreenshot = function () {
+    if (ref.current === null) {
+      return;
+    }
+
+    toPng(ref.current, { cacheBust: true })
+      .then((dataUrl) => {
+        dispatch(setImage({ slide: selectedSlide, image: dataUrl }));
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  };
+
+  const onLayoutSelected = (i_layout: string | null) => {
+    dispatch(setLayoutForSlide({ slide: selectedSlide, layout: i_layout }));
+  };
+
+  const { numberOfVis, numberOfContentPanes, vertical } = SlideLayouts[
+    selectedSlide!.layout
+  ] as SlideLayout;
+
+  const increaseNumberOfContentPanes = () => {
+    if (numberOfContentPanes === 0) {
+      for (const key of Object.keys(SlideLayouts)) {
+        const layout = SlideLayouts[key];
+        if (
+          layout!.numberOfContentPanes === 1 &&
+          layout!.vertical === vertical &&
+          layout!.numberOfVis === numberOfVis
+        ) {
+          dispatch(setLayoutForSlide({ slide: selectedSlide, layout: key }));
+        }
+      }
+    }
+  };
+
+  return (
+    <div className="grid  h-full w-full grid-rows-[max-content_1fr]">
+      <StroyCreatorToolbar
+        onLayoutSelected={onLayoutSelected}
+        desktop={desktop}
+        onDesktopChange={onDesktopChange}
+        timescale={timescale}
+        onTimescaleChange={onTimescaleChange}
+      />
+      <ReactResizeDetector key="test" handleWidth handleHeight>
+        {({ width, height }) => {
+          const aspectRatio = 3 / 4;
+          let newWidth;
+          if (height !== undefined) {
+            newWidth = desktop ? width : aspectRatio * height;
+          } else {
+            newWidth = 'unset';
+          }
+          return (
+            <div className="grid h-full w-full grid-cols-1 justify-items-center">
+              <div className="h-full border border-intavia-gray-300" style={{ width: newWidth }}>
+                <SlideEditor
+                  slide={selectedSlide as Slide}
+                  //imageRef={ref}
+                  takeScreenshot={takeScreenshot}
+                  numberOfVisPanes={numberOfVis}
+                  numberOfContentPanes={numberOfContentPanes}
+                  vertical={vertical}
+                  desktop={desktop}
+                  timescale={timescale}
+                  increaseNumberOfContentPanes={increaseNumberOfContentPanes}
+                />
+              </div>
+            </div>
+          );
+        }}
+      </ReactResizeDetector>
+    </div>
+  );
+}
+
+{
+  /* <div className={`h-full ${desktop ? 'w-full' : 'w-1/3'} border border-black`}>
+          <SlideEditor
+            slide={selectedSlide as Slide}
+            //imageRef={ref}
+            takeScreenshot={takeScreenshot}
+            numberOfVisPanes={numberOfVis}
+            numberOfContentPanes={numberOfContentPanes}
+            vertical={vertical}
+            desktop={desktop}
+            timescale={timescale}
+            increaseNumberOfContentPanes={increaseNumberOfContentPanes}
+          />
+        </div> */
+}

--- a/src/features/storycreator/story-center-pane.tsx
+++ b/src/features/storycreator/story-center-pane.tsx
@@ -101,7 +101,7 @@ export function StoryCenterPane(props: StoryCenterPaneProps): JSX.Element {
 
   const ref = useRef<HTMLDivElement>(null);
 
-  const takeScreenshot = function () {
+  const setSlideThumbnail = function () {
     if (ref.current === null) {
       return;
     }
@@ -160,6 +160,8 @@ export function StoryCenterPane(props: StoryCenterPaneProps): JSX.Element {
  */
   };
 
+  setSlideThumbnail();
+
   return (
     <div className="grid  h-full w-full grid-rows-[max-content_1fr]">
       <StroyCreatorToolbar
@@ -183,8 +185,7 @@ export function StoryCenterPane(props: StoryCenterPaneProps): JSX.Element {
               <div className="h-full border border-intavia-gray-300" style={{ width: newWidth }}>
                 <SlideEditor
                   slide={selectedSlide as Slide}
-                  //imageRef={ref}
-                  takeScreenshot={takeScreenshot}
+                  imageRef={ref}
                   layout={selectedSlide!.layout}
                   desktop={desktop}
                   timescale={timescale}

--- a/src/features/storycreator/story-creator-toolbar.tsx
+++ b/src/features/storycreator/story-creator-toolbar.tsx
@@ -1,9 +1,10 @@
 import SlideLayoutButton from '@/features/storycreator/slide-layout-popover';
+import type { PanelLayout } from '@/features/ui/analyse-page-toolbar/layout-popover';
 import { PaneToggle } from '@/features/ui/analyse-page-toolbar/PaneToggle';
 import Button from '@/features/ui/Button';
 
 interface StroyCreatorToolbarProps {
-  onLayoutSelected: (layout: string) => void;
+  onLayoutSelected: (layout: PanelLayout) => void;
   desktop: boolean;
   onDesktopChange: (desktop: boolean) => void;
   timescale: boolean;

--- a/src/features/storycreator/story-creator-toolbar.tsx
+++ b/src/features/storycreator/story-creator-toolbar.tsx
@@ -1,0 +1,48 @@
+import SlideLayoutButton from '@/features/storycreator/slide-layout-popover';
+import { PaneToggle } from '@/features/ui/analyse-page-toolbar/PaneToggle';
+import Button from '@/features/ui/Button';
+
+interface StroyCreatorToolbarProps {
+  onLayoutSelected: (layout: string) => void;
+  desktop: boolean;
+  onDesktopChange: (desktop: boolean) => void;
+  timescale: boolean;
+  onTimescaleChange: (timescale: boolean) => void;
+}
+
+export default function StroyCreatorToolbar(props: StroyCreatorToolbarProps): JSX.Element {
+  /* const { split = false, onSplit, onSave } = props; */
+  const { desktop, onDesktopChange, timescale, onTimescaleChange } = props;
+
+  return (
+    <div className="w-100 flex h-fit justify-between gap-2 bg-intavia-brand-100 p-2">
+      <div className="flex gap-3">
+        <PaneToggle parentComponent="stc" orientation="left" />
+        <SlideLayoutButton onLayoutSelected={props.onLayoutSelected} />
+        <Button
+          size="small"
+          round="pill"
+          color="accent"
+          onClick={() => {
+            onDesktopChange(!desktop);
+          }}
+        >
+          {desktop ? 'Mobile' : 'Desktop'}
+        </Button>
+        <Button
+          size="small"
+          round="pill"
+          color="accent"
+          onClick={() => {
+            onTimescaleChange(!timescale);
+          }}
+        >
+          {timescale ? 'Timescale' : 'No Timescale'}
+        </Button>
+      </div>
+      <div className="flex">
+        <PaneToggle parentComponent="stc" orientation="right" />
+      </div>
+    </div>
+  );
+}

--- a/src/features/storycreator/story-timeline.tsx
+++ b/src/features/storycreator/story-timeline.tsx
@@ -1,0 +1,41 @@
+import { useRef } from 'react';
+
+import { useAppSelector } from '@/app/store';
+import { selectEntitiesByKind } from '@/features/common/entities.slice';
+import type { EntityEvent, StoryEvent } from '@/features/common/entity.model';
+import styles from '@/features/timeline/timeline.module.css';
+import { selectZoomToTimeRange } from '@/features/timeline/timeline.slice';
+import { TimelineSvg } from '@/features/timeline/timeline-svg';
+
+interface StoryTimelineProps {
+  events: Array<EntityEvent | StoryEvent>;
+}
+
+export function StoryTimeline(props: StoryTimelineProps): JSX.Element {
+  const { events } = props;
+
+  const zoomToTimeRange = useAppSelector(selectZoomToTimeRange);
+
+  const parent = useRef<HTMLDivElement>(null);
+
+  const entitiesByKind = useAppSelector(selectEntitiesByKind);
+  const allPersons = Object.values(entitiesByKind.person);
+
+  const persons = events.flatMap((event) => {
+    return allPersons.filter((p) => {
+      return p.id === event.targetId;
+    });
+  });
+
+  return (
+    <div className={styles['timeline-wrapper']} ref={parent}>
+      <TimelineSvg
+        parentRef={parent}
+        persons={persons}
+        events={events}
+        zoomToData={zoomToTimeRange}
+        renderLabel={true}
+      />
+    </div>
+  );
+}

--- a/src/features/storycreator/story-timeline.tsx
+++ b/src/features/storycreator/story-timeline.tsx
@@ -1,31 +1,22 @@
 import { useRef } from 'react';
 
 import { useAppSelector } from '@/app/store';
-import { selectEntitiesByKind } from '@/features/common/entities.slice';
-import type { EntityEvent, StoryEvent } from '@/features/common/entity.model';
+import type { EntityEvent, Person, StoryEvent } from '@/features/common/entity.model';
 import styles from '@/features/timeline/timeline.module.css';
 import { selectZoomToTimeRange } from '@/features/timeline/timeline.slice';
 import { TimelineSvg } from '@/features/timeline/timeline-svg';
 
 interface StoryTimelineProps {
   events: Array<EntityEvent | StoryEvent>;
+  persons: Array<Person>;
 }
 
 export function StoryTimeline(props: StoryTimelineProps): JSX.Element {
-  const { events } = props;
+  const { events, persons } = props;
 
   const zoomToTimeRange = useAppSelector(selectZoomToTimeRange);
 
   const parent = useRef<HTMLDivElement>(null);
-
-  const entitiesByKind = useAppSelector(selectEntitiesByKind);
-  const allPersons = Object.values(entitiesByKind.person);
-
-  const persons = events.flatMap((event) => {
-    return allPersons.filter((p) => {
-      return p.id === event.targetId;
-    });
-  });
 
   return (
     <div className={styles['timeline-wrapper']} ref={parent}>

--- a/src/features/storycreator/storycreator.module.css
+++ b/src/features/storycreator/storycreator.module.css
@@ -29,7 +29,8 @@
 .slide-editor-wrapper {
   width: 100%;
   height: 100%;
-  border: solid 1px rgb(0 0 0);
+
+  /* border: solid 1px rgb(0 0 0); */
 }
 
 .elevated {
@@ -63,7 +64,7 @@
 }
 
 .story-flow-card.selected {
-  border: 3px solid var(--light-blue) !important;
+  border: 2px solid var(--light-blue) !important;
 }
 
 .button-row {

--- a/src/features/storycreator/storycreator.slice.ts
+++ b/src/features/storycreator/storycreator.slice.ts
@@ -3,8 +3,12 @@ import { createSelector, createSlice } from '@reduxjs/toolkit';
 
 import type { RootState } from '@/app/store';
 import type { StoryEvent } from '@/features/common/entity.model';
+import type { PanelLayout } from '@/features/ui/analyse-page-toolbar/layout-popover';
+import type { SlotId } from '@/features/visualization-layouts/workspaces.slice';
 
 type DataUrlString = string;
+
+export type ContentSlotId = 'cont-1' | 'cont-2';
 
 export interface StoryMapMarker {
   position: [number, number];
@@ -24,11 +28,6 @@ export interface SlideContent {
   properties?: Record<StoryContentProperty['id'], StoryContentProperty>;
 }
 
-export interface ContentPane {
-  id: string;
-  contents: Record<SlideContent['id'], SlideContent>;
-}
-
 export interface VisualisationPane {
   id: string;
   events: Array<StoryEvent>;
@@ -41,10 +40,12 @@ export interface Slide {
   sort: number;
   selected?: boolean;
   image?: DataUrlString | null;
-  contentPanes: Record<ContentPane['id'], ContentPane>;
-  visualizationPanes: Record<VisualisationPane['id'], VisualisationPane>;
+  /* contentPanes: Record<ContentPane['id'], ContentPane>;
+  visualizationPanes: Record<VisualisationPane['id'], VisualisationPane>; */
   story: Story['id'];
-  layout: string;
+  layout: PanelLayout;
+  visualizationSlots: Record<SlotId, string | null>;
+  contentPaneSlots: Record<ContentSlotId, string | null>;
 }
 
 export interface Story {
@@ -222,17 +223,11 @@ const initialState: StoryCreatorState = {
           id: '0',
           sort: 0,
           story: 'story0',
-          visualizationPanes: {
-            vis0: { id: 'vis0', events: [], contents: {} },
-            vis1: { id: 'vis1', events: [], contents: {} },
-          },
-          contentPanes: {
-            contentPane0: { id: 'contentPane0', contents: {} },
-            contentPane1: { id: 'contentPane1', contents: {} },
-          },
+          visualizationSlots: { 'vis-1': null, 'vis-2': null, 'vis-3': null, 'vis-4': null },
+          contentPaneSlots: { 'cont-1': null, 'cont-2': null },
           selected: true,
           image: null,
-          layout: 'singlevis',
+          layout: 'single-vis',
         },
       },
     },
@@ -245,16 +240,10 @@ const initialState: StoryCreatorState = {
           sort: 0,
           story: 'story2',
           selected: true,
-          visualizationPanes: {
-            vis0: { id: 'vis0', events: [], contents: {} },
-            vis1: { id: 'vis1', events: [], contents: {} },
-          },
-          contentPanes: {
-            contentPane0: { id: 'contentPane0', contents: {} },
-            contentPane1: { id: 'contentPane1', contents: {} },
-          },
+          visualizationSlots: { 'vis-1': null, 'vis-2': null, 'vis-3': null, 'vis-4': null },
+          contentPaneSlots: { 'cont-1': null, 'cont-2': null },
           image: null,
-          layout: 'singlevis',
+          layout: 'single-vis',
         },
       },
     },
@@ -285,15 +274,9 @@ export const storyCreatorSlice = createSlice({
           story: story.id,
           selected: true,
           image: null,
-          visualizationPanes: {
-            vis0: { id: 'vis0', events: [], contents: {} },
-            vis1: { id: 'vis1', events: [], contents: {} },
-          },
-          contentPanes: {
-            contentPane0: { id: 'contentPane0', contents: {} },
-            contentPane1: { id: 'contentPane1', contents: {} },
-          },
-          layout: 'singlevis',
+          visualizationSlots: { 'vis-1': null, 'vis-2': null },
+          contentPaneSlots: { 'cont-1': null, 'cont-2': null },
+          layout: 'single-vis',
         } as Slide,
       };
       newStories[story.id] = story;
@@ -325,15 +308,9 @@ export const storyCreatorSlice = createSlice({
         id: newID,
         image: null,
         //FIXME: Define default contentPanes and visualizationPanes
-        visualizationPanes: {
-          vis0: { id: 'vis0', events: [], contents: {} },
-          vis1: { id: 'vis1', events: [], contents: {} },
-        },
-        layout: 'singlevis',
-        contentPanes: {
-          contentPane0: { id: 'contentPane0', contents: {} },
-          contentPane1: { id: 'contentPane1', contents: {} },
-        },
+        visualizationSlots: { 'vis-1': null, 'vis-2': null },
+        contentPaneSlots: { 'cont-1': null, 'cont-2': null },
+        layout: 'single-vis',
         sort: counter,
         selected: false,
       } as Slide;
@@ -418,178 +395,52 @@ export const storyCreatorSlice = createSlice({
 
       state.stories = newStories;
     },
-    removeSlideContent: (state, action) => {
-      const content = action.payload.content;
-      const slide = action.payload.slide;
-
-      console.log(JSON.stringify(content));
-
-      switch (content.type) {
-        case 'Text':
-        case 'Image':
-        case 'Quiz':
-          delete state.stories[slide.story]!.slides[slide.id]!.contentPanes[content.parentPane]!
-            .contents[content.id];
-          break;
-        case 'Map':
-        case 'Timeline':
-          delete state.stories[slide.story]!.slides[slide.id]!.visualizationPanes[
-            content.parentPane
-          ]!.contents[content.id];
-      }
-    },
     setSlidesForStory: (state, action) => {
       const story = action.payload.story;
       const slides = action.payload.slides;
 
       state.stories[story]!.slides = slides;
     },
-    addVisualization: (state, action) => {
-      const content = action.payload;
-
-      console.log(content);
-
-      const visPaneId = content.parentPane;
-      const contentId = `content1`;
-      content.id = contentId;
-
-      const newContents = {} as Record<SlideContent['id'], SlideContent>;
-      newContents[contentId] = content as SlideContent;
-
-      state.stories[content.story]!.slides[content.slide]!.visualizationPanes[visPaneId] = {
-        id: visPaneId,
-        type: content.type,
-        events: [],
-        contents: newContents,
-      } as VisualisationPane;
+    setContentPaneToSlot: (state, action) => {
+      const { id, slotId, slide } = action.payload;
+      state.stories[slide.story]!.slides[slide.id]!.contentPaneSlots[slotId as ContentSlotId] = id;
     },
-    editSlideContent: (state, action) => {
-      const content = action.payload.content;
+    setVisualizationForVisualizationSlotForStorySlide: (state, action) => {
       const slide = action.payload.slide;
+      const visualizationSlot = action.payload.visualizationSlot;
+      const visualizationId = action.payload.visualizationId;
 
-      switch (content.type) {
-        case 'Text':
-        case 'Image':
-        case 'Quiz':
-          state.stories[slide.story]!.slides[slide.id]!.contentPanes[content.parentPane]!.contents[
-            content.id
-          ] = content;
-          break;
-        case 'Map':
-        case 'Timeline':
-          state.stories[slide.story]!.slides[slide.id]!.visualizationPanes[
-            content.parentPane
-          ]!.contents[content.id] = content;
-      }
+      state.stories[slide.story]!.slides[slide.id]!.visualizationSlots[
+        visualizationSlot as SlotId
+      ] = visualizationId;
+
+      /* console.log(slide, visualizationSlot, visualizationId); */
     },
-    addContentToContentPane: (state, action) => {
-      const content = action.payload;
-
-      const contentPaneID = content.contentPane;
-      const contentPane =
-        state.stories[content.story]!.slides[content.slide]!.contentPanes[contentPaneID];
-      //const contentId = `content${Object.keys(contentPane?.contents).length}`;
-
-      const contents = contentPane?.contents;
-      const oldIDs = Object.keys(contents as object);
-
-      let counter = 0;
-      let newID;
-      do {
-        counter = counter + 1;
-        newID = `${content.slide}(${counter})`;
-      } while (oldIDs.includes(newID));
-
-      content.id = newID;
-
-      let contentObject;
-      switch (content.type) {
-        case 'Image':
-          contentObject = new StoryImageObject(content.id, content.contentPane, content.layout);
-          break;
-        case 'Text':
-          contentObject = new StoryTextObject(content.id, content.contentPane, content.layout);
-          break;
-        case 'Quiz':
-          contentObject = new StoryQuizObject(content.id, content.contentPane, content.layout);
-          break;
-        default:
-          break;
-      }
-
-      if (contentObject !== undefined) {
-        state.stories[content.story]!.slides[content.slide]!.contentPanes[contentPaneID]!.contents[
-          newID
-        ] = contentObject;
-      }
-    },
-    resizeMoveContent: (state, action) => {
-      const layout = action.payload.layout;
+    releaseVisualizationForVisualizationSlotForSlide: (state, action) => {
       const slide = action.payload.slide;
-      const story = action.payload.story;
-      const content = action.payload.content;
-      const parentPane = action.payload.parentPane;
-      const type = action.payload.parentType;
-      let objectToChange;
+      const visSlot = action.payload.visSlot;
 
-      switch (type) {
-        case 'Content':
-          objectToChange =
-            state.stories[story]!.slides[slide]!.contentPanes[parentPane]!.contents[content];
-          if (objectToChange !== undefined) {
-            objectToChange.layout = {
-              x: layout.x,
-              y: layout.y,
-              w: layout.w,
-              h: layout.h,
-            };
-          }
-          break;
-        case 'Visualization':
-          objectToChange =
-            state.stories[story]!.slides[slide]!.visualizationPanes[parentPane]!.contents[content];
-          if (objectToChange !== undefined) {
-            objectToChange.layout = {
-              x: layout.x,
-              y: layout.y,
-              w: layout.w,
-              h: layout.h,
-            };
-          }
-          break;
-        default:
-          break;
-      }
+      state.stories[slide.story]!.slides[slide.id]!.visualizationSlots[visSlot as SlotId] = null;
     },
-    editContentOfContentPane: (state, action) => {
+    switchVisualizations(state, action) {
+      const { targetSlot, targetVis, sourceSlot, sourceVis, slide } = action.payload;
+
+      state.stories[slide.story]!.slides[slide.id]!.visualizationSlots[targetSlot as SlotId] =
+        targetVis;
+      state.stories[slide.story]!.slides[slide.id]!.visualizationSlots[sourceSlot as SlotId] =
+        sourceVis;
+    },
+    /* editContentOfContentPane: (state, action) => {
       const content = action.payload;
 
       console.log(JSON.stringify(content));
 
       state.stories[content.story]!.slides[content.slide]!.contentPanes[content.id] = content;
-    },
+    }, */
     setImage: (state, action) => {
       const slide = action.payload.slide;
       const image = action.payload.image;
       state.stories[slide.story]!.slides[slide.id]!.image = image;
-    },
-    addEventsToVisPane: (state, action) => {
-      const slide: Slide = action.payload.slide;
-      const visPaneId: string = action.payload.visPane;
-      const events: Array<StoryEvent> = action.payload.events;
-
-      state.stories[slide.story]!.slides[slide.id]!.visualizationPanes[visPaneId]?.events.push(
-        ...events,
-      );
-    },
-    addEventToVisPane: (state, action) => {
-      const slide: Slide = action.payload.slide;
-      const visPaneId: string = action.payload.visPane;
-      const event: StoryEvent = action.payload.event;
-
-      state.stories[slide.story]!.slides[slide.id]!.visualizationPanes[visPaneId]?.events.push(
-        event,
-      );
     },
   },
 });
@@ -599,21 +450,17 @@ export const {
   editStory,
   removeStory,
   removeSlide,
-  removeSlideContent,
   createSlide,
   selectSlide,
-  addVisualization,
-  addContentToContentPane,
-  resizeMoveContent,
-  editSlideContent,
-  editContentOfContentPane,
   setImage,
   copySlide,
   createSlidesInBulk,
-  addEventsToVisPane,
-  addEventToVisPane,
   setLayoutForSlide,
   setSlidesForStory,
+  setVisualizationForVisualizationSlotForStorySlide,
+  releaseVisualizationForVisualizationSlotForSlide,
+  setContentPaneToSlot,
+  switchVisualizations,
 } = storyCreatorSlice.actions;
 
 export const selectStoryByID = createSelector(

--- a/src/features/storycreator/storycreator.slice.ts
+++ b/src/features/storycreator/storycreator.slice.ts
@@ -447,6 +447,8 @@ export const storyCreatorSlice = createSlice({
     addVisualization: (state, action) => {
       const content = action.payload;
 
+      console.log(content);
+
       const visPaneId = content.parentPane;
       const contentId = `content1`;
       content.id = contentId;

--- a/src/features/storycreator/visualization-dragger.tsx
+++ b/src/features/storycreator/visualization-dragger.tsx
@@ -100,8 +100,8 @@ export function VisualizationDragger(): JSX.Element {
   return (
     <div className="grid w-full p-2">
       {[
-        createDrops({ type: 'Map' }),
-        createDrops({ type: 'Timeline' }),
+        /* createDrops({ type: 'Map' }),
+        createDrops({ type: 'Timeline' }), */
         createDrops({ type: 'Text' }),
         createDrops({ type: 'Image' }),
         createDrops({ type: 'Quiz' }),

--- a/src/features/storycreator/visualization-dragger.tsx
+++ b/src/features/storycreator/visualization-dragger.tsx
@@ -1,0 +1,111 @@
+import '~/node_modules/react-grid-layout/css/styles.css';
+import '~/node_modules/react-resizable/css/styles.css';
+
+import type { Place } from '@/features/common/entity.model';
+import { DroppableIcon } from '@/features/storycreator/DroppableIcon';
+
+interface DropProps {
+  name?: string | null;
+  title?: string | null;
+  label?: string | null;
+  type: string;
+  place?: Place | null;
+  date?: IsoDateString;
+}
+
+export function VisualizationDragger(): JSX.Element {
+  const createDrops = (props: DropProps) => {
+    const { type } = props;
+
+    const content = [<DroppableIcon key={`${type}Icon`} type={type} />];
+    let text = '';
+    let subline = '';
+    let padding = 0;
+    let key = `${type}Drop`;
+    switch (type) {
+      case 'Person':
+        if (props.name != null) {
+          text = props.name;
+        }
+        key = key + props.name;
+        padding = 5;
+        break;
+      case 'Event':
+        if (props.label != null) {
+          text = props.label;
+        } else {
+          text = type;
+        }
+
+        key = key + JSON.stringify(props);
+        if (props.place != null) {
+          subline = `in ${props.place.name}`;
+        }
+        if (props.date !== undefined && props.date !== '') {
+          subline += ` in ${props.date.substring(0, 4)}`;
+        }
+        padding = 5;
+        break;
+      default:
+        text = type;
+        padding = 5;
+        break;
+    }
+
+    content.push(
+      <div
+        key="imageLabel"
+        style={{
+          verticalAlign: 'middle',
+          paddingLeft: '10px',
+          display: 'table-cell',
+        }}
+      >
+        {text}
+        <br />
+        {subline}
+      </div>,
+    );
+
+    return (
+      <div
+        key={key}
+        className="droppable-element"
+        draggable={true}
+        unselectable="on"
+        onDragStart={(e) => {
+          return e.dataTransfer.setData(
+            'Text',
+            JSON.stringify({
+              type: type,
+              props: props,
+              content: '',
+            }),
+          );
+        }}
+        style={{
+          border: 'solid 1px black',
+          padding: padding,
+          marginBottom: 10,
+          cursor: 'pointer',
+          display: 'table',
+          width: '100%',
+        }}
+      >
+        <div style={{ display: 'table-row', width: '100%' }}>{content}</div>
+      </div>
+    );
+  };
+
+  return (
+    <div className="grid w-full p-2">
+      {[
+        createDrops({ type: 'Map' }),
+        createDrops({ type: 'Timeline' }),
+        createDrops({ type: 'Text' }),
+        createDrops({ type: 'Image' }),
+        createDrops({ type: 'Quiz' }),
+      ]}
+    </div>
+  );
+}

--- a/src/features/timeline/timeline-svg.tsx
+++ b/src/features/timeline/timeline-svg.tsx
@@ -30,6 +30,7 @@ export function TimelineSvg(props: TimelineSvgProps): JSX.Element {
     hoveredEntityId,
     setHoveredEntityId,
   } = props;
+
   const [svgViewBox, setSvgViewBox] = useState(`0 0 ${svgMinWidth} ${svgMinHeight}`);
   const [svgWidth, setSvgWidth] = useState(svgMinWidth);
   const [svgHeight, setSvgHeight] = useState(svgMinHeight);

--- a/src/features/timeline/timeline-svg.tsx
+++ b/src/features/timeline/timeline-svg.tsx
@@ -3,13 +3,14 @@ import { scaleBand, scaleTime } from 'd3-scale';
 import type { RefObject } from 'react';
 import { useEffect, useState } from 'react';
 
-import type { Entity, Person } from '@/features/common/entity.model';
+import type { Entity, EntityEvent, Person, StoryEvent } from '@/features/common/entity.model';
 import { TimelineElement } from '@/features/timeline/timeline-element';
 import { TimelineElementTooltip } from '@/features/timeline/timeline-element-tooltip';
 import { TimelineYearAxis } from '@/features/timeline/timeline-year-axis';
 
 interface TimelineSvgProps {
   persons: Array<Person>;
+  events?: Array<EntityEvent | StoryEvent>;
   parentRef: RefObject<HTMLDivElement>;
   zoomToData: boolean;
   renderLabel: boolean;
@@ -21,11 +22,26 @@ const svgMinWidth = 300;
 const svgMinHeight = 150;
 
 export function TimelineSvg(props: TimelineSvgProps): JSX.Element {
-  const { parentRef, persons, zoomToData, renderLabel, hoveredEntityId, setHoveredEntityId } =
-    props;
+  const {
+    parentRef,
+    events = [],
+    zoomToData,
+    renderLabel,
+    hoveredEntityId,
+    setHoveredEntityId,
+  } = props;
   const [svgViewBox, setSvgViewBox] = useState(`0 0 ${svgMinWidth} ${svgMinHeight}`);
   const [svgWidth, setSvgWidth] = useState(svgMinWidth);
   const [svgHeight, setSvgHeight] = useState(svgMinHeight);
+
+  const persons = props.persons.map((person) => {
+    return {
+      ...person,
+      history: events.filter((event) => {
+        return event.targetId === person.id;
+      }),
+    } as Person;
+  });
 
   // FIXME:
   useEffect(() => {

--- a/src/features/ui/AllotmentHeader.tsx
+++ b/src/features/ui/AllotmentHeader.tsx
@@ -1,8 +1,26 @@
+import { ChevronUpIcon } from '@heroicons/react/solid';
+
 export interface AllotmentHeaderProps {
   title?: string;
+  onClick?: () => void;
+  open?: boolean;
 }
 
 export default function AllotmentHeader(props: AllotmentHeaderProps): JSX.Element {
-  const { title } = props;
-  return <div className="h-7 bg-intavia-green-100">{title}</div>;
+  const { title, onClick, open } = props;
+  return (
+    <div className="flex h-6 w-full items-center justify-between bg-intavia-brand-100 p-2 text-intavia-gray-700">
+      <div>{title}</div>
+      <div className="flex">
+        <button className="h-full bg-transparent">
+          <ChevronUpIcon
+            onClick={onClick}
+            className={`${
+              open === true ? 'rotate-180 transform' : ''
+            } h-5 w-5 text-intavia-brand-800`}
+          />
+        </button>
+      </div>
+    </div>
+  );
 }

--- a/src/features/ui/AppBar.tsx
+++ b/src/features/ui/AppBar.tsx
@@ -1,4 +1,4 @@
-import { DownloadIcon, InformationCircleIcon } from '@heroicons/react/outline';
+import { InformationCircleIcon, UploadIcon } from '@heroicons/react/outline';
 import { clsx } from 'clsx';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -87,7 +87,7 @@ export function AppBar(): JSX.Element {
         </div>
         <div className="flex h-16 flex-row items-center gap-6 pr-6">
           <Button color="accent" round="pill" className="flex items-center gap-2">
-            <DownloadIcon className="h-5 w-5" strokeWidth="1.75" />
+            <UploadIcon className="h-5 w-5" strokeWidth="1.75" />
             {t(['common', 'data-import'])}
           </Button>
           {linksRight.map((item) => {

--- a/src/features/ui/Button.tsx
+++ b/src/features/ui/Button.tsx
@@ -4,7 +4,7 @@ import { forwardRef } from 'react';
 
 const buttonSizes = {
   'extra-small': 'text-xs p-1 px-2 py-1 font-extralight',
-  small: 'text-sm p-1.5 px-3 py-1.5 font-light',
+  small: 'text-sm p-1.5 px-3 py-1.5 font-normal',
   regular: 'text-base p-2 px-4 py-2 font-normal',
   large: 'text-lg p-2.5 px-5 py-2.5 font-semibold',
   'extra-large': 'text-xl p-4 px-8 py-4 font-bold',

--- a/src/features/ui/Popover.tsx
+++ b/src/features/ui/Popover.tsx
@@ -72,7 +72,7 @@ export default function Popover(passedProps: PopoverProperties): JSX.Element {
                 <HeadlessPopover.Overlay className="fixed inset-0 bg-black opacity-30" />
               )}
               <HeadlessPopover.Panel
-                className={`rounded-lg bg-white p-4 drop-shadow-lg ${panelClassName}`}
+                className={`z-50 rounded-lg bg-white p-4 drop-shadow-lg ${panelClassName}`}
                 ref={setPopperElement}
                 style={styles.popper}
                 {...attributes.popper}

--- a/src/features/ui/analyse-page-toolbar/PaneToggle.tsx
+++ b/src/features/ui/analyse-page-toolbar/PaneToggle.tsx
@@ -30,7 +30,9 @@ export function PaneToggle(props: PaneToggleProps): JSX.Element {
           );
         }}
       >
-        <LoginIcon className={`${!isOpen ? 'rotate-180 transform' : ''} h-5 w-5 text-purple-500`} />
+        <LoginIcon
+          className={`${!isOpen ? 'rotate-180 transform' : ''} h-5 w-5 text-intavia-brand-800`}
+        />
       </button>
     );
   } else {
@@ -46,7 +48,9 @@ export function PaneToggle(props: PaneToggleProps): JSX.Element {
           );
         }}
       >
-        <LoginIcon className={`${isOpen ? 'rotate-180 transform' : ''} h-5 w-5 text-purple-500`} />
+        <LoginIcon
+          className={`${isOpen ? 'rotate-180 transform' : ''} h-5 w-5 text-intavia-brand-800`}
+        />
       </button>
     );
   }

--- a/src/features/ui/analyse-page-toolbar/layout-popover.tsx
+++ b/src/features/ui/analyse-page-toolbar/layout-popover.tsx
@@ -1,5 +1,7 @@
-import { Popover, Transition } from '@headlessui/react';
-import { ChevronRightIcon } from '@heroicons/react/solid';
+import { ChevronDownIcon, ChevronRightIcon, ChevronUpIcon } from '@heroicons/react/solid';
+import { Fragment } from 'react';
+
+import Popover from '@/features/ui/Popover';
 
 export interface LayoutOptionData {
   key: string;
@@ -64,55 +66,54 @@ export interface LayoutButtonProps {
 
 export default function LayoutButton(props: LayoutButtonProps): JSX.Element {
   return (
-    <Popover className="relative">
-      {({ open, close }) => {
+    <Popover buttonClassName="flex gap-1 items-center" panelClassName="z-50" noOverlay={true}>
+      {({ open, placement }) => {
         return (
-          <>
-            <Popover.Button className="flex gap-1 rounded-lg bg-intavia-brand-700 p-2 text-white hover:bg-intavia-brand-900">
-              <ChevronRightIcon className={`${open ? 'rotate-90 transform' : ''} h-5 w-5`} />
-              <span>Layouts</span>
-            </Popover.Button>
+          <Fragment>
+            Layouts
+            {open ? (
+              placement === 'bottom' ? (
+                <ChevronDownIcon className="h-5 w-5" />
+              ) : (
+                <ChevronUpIcon className="h-5 w-5" />
+              )
+            ) : (
+              <ChevronRightIcon className="h-5 w-5" />
+            )}
+          </Fragment>
+        );
+      }}
 
-            <Transition
-              enter="transition duration-100 ease-out"
-              enterFrom="transform scale-95 opacity-0"
-              enterTo="transform scale-100 opacity-100"
-              leave="transition duration-75 ease-out"
-              leaveFrom="transform scale-100 opacity-100"
-              leaveTo="transform scale-95 opacity-0"
-            >
-              <Popover.Panel className="absolute z-10 mt-4 w-[32rem]">
-                <div className="max-h-54 grid grid-cols-2 gap-4 overflow-y-auto rounded-md bg-white p-4 text-gray-800 drop-shadow-2xl">
-                  {layoutOptions.map((option) => {
-                    return (
-                      <button
-                        key={option.key}
-                        className="grid grid-cols-[3.6rem_1fr] grid-rows-[1.2rem_2.4rem] gap-1 rounded bg-white p-1 hover:bg-slate-100 active:bg-slate-300"
-                        onClick={() => {
-                          props.onLayoutSelected(option.key);
-                          close();
-                        }}
-                      >
-                        <svg className="col-1 row-span-full" viewBox="-0.3 -0.3 1.6 1.6">
-                          <path
-                            d={option.symbol}
-                            strokeWidth={0.02}
-                            shapeRendering="crispEdges"
-                            fill="none"
-                            stroke="currentColor"
-                          />
-                        </svg>
-                        <span className="col-2 row-1 text-left font-semibold">{option.title}</span>
-                        <p className="col-2 row-1 text-left font-light">
-                          {option.description ?? ''}
-                        </p>
-                      </button>
-                    );
-                  })}
-                </div>
-              </Popover.Panel>
-            </Transition>
-          </>
+      {({ close }) => {
+        return (
+          <Fragment>
+            <div className="max-h-54 z-50 grid grid-cols-2 gap-4 overflow-y-auto rounded-md bg-white p-4 text-gray-800 drop-shadow-2xl">
+              {layoutOptions.map((option) => {
+                return (
+                  <button
+                    key={option.key}
+                    className="grid grid-cols-[3.6rem_1fr] grid-rows-[1.2rem_2.4rem] gap-1 rounded bg-white p-1 hover:bg-slate-100 active:bg-slate-300"
+                    onClick={() => {
+                      props.onLayoutSelected(option.key);
+                      close();
+                    }}
+                  >
+                    <svg className="col-1 row-span-full" viewBox="-0.3 -0.3 1.6 1.6">
+                      <path
+                        d={option.symbol}
+                        strokeWidth={0.02}
+                        shapeRendering="crispEdges"
+                        fill="none"
+                        stroke="currentColor"
+                      />
+                    </svg>
+                    <span className="col-2 row-1 text-left font-semibold">{option.title}</span>
+                    <p className="col-2 row-1 text-left font-light">{option.description ?? ''}</p>
+                  </button>
+                );
+              })}
+            </div>
+          </Fragment>
         );
       }}
     </Popover>

--- a/src/features/ui/analyse-page-toolbar/layout-popover.tsx
+++ b/src/features/ui/analyse-page-toolbar/layout-popover.tsx
@@ -5,63 +5,126 @@ import Popover from '@/features/ui/Popover';
 
 export interface LayoutOptionData {
   key: string;
-  symbol: string;
+  symbol?: string;
   title: string;
   description?: string;
 }
-const layoutOptions: Array<LayoutOptionData> = [
-  {
-    key: 'single-pane',
+
+export const visLayout = [
+  'single-vis',
+  'two-cols',
+  'two-rows',
+  'three-cols',
+  'three-rows',
+  'two-rows-one-left',
+  'two-rows-one-right',
+  'grid-2x2',
+] as const;
+
+type VisLayout = typeof visLayout[number];
+
+export interface VisOptionData extends LayoutOptionData {
+  key: VisLayout;
+}
+
+export const storyLayout = [
+  'single-vis',
+  'single-vis-content',
+  'two-cols',
+  'two-cols-content',
+  'two-rows',
+  'two-rows-content',
+  'two-contents',
+] as const;
+
+export type StoryLayout = typeof storyLayout[number];
+export type PanelLayout = StoryLayout | VisLayout;
+
+export interface StoryVisOptionData extends LayoutOptionData {
+  key: StoryLayout;
+  contentSymbol?: string;
+}
+
+export const layoutOptions: Record<PanelLayout, LayoutOptionData> = {
+  'single-vis': {
+    key: 'single-vis',
     symbol: 'M0 0H1V1H0z',
-    title: 'Single Pane',
-    description: 'Show only one pane, in full size.',
+    title: 'Single Vis',
+    description: 'Show only one vis, in full size.',
   },
-  {
+  'two-rows': {
     key: 'two-rows',
     symbol: 'M0 0H1V0.5H0z M0 0.5H1V1H0z',
     title: 'Two Rows',
-    description: 'Two panes, stacked on top of each other.',
+    description: 'Two vis, stacked on top of each other.',
   },
-  {
+  'two-cols': {
     key: 'two-cols',
     symbol: 'M0 0H1V1H0zM0.5 0V1',
     title: 'Two Columns',
-    description: 'Two panes, placed next to each other.',
+    description: 'Two vis, placed next to each other.',
   },
-  {
+  'three-rows': {
     key: 'three-rows',
     symbol: 'M0 0H1V1H0zM0 0.33H1M0 0.67H1',
     title: 'Three Rows',
-    description: 'Three panes, stacked on top of each other.',
+    description: 'Three vis, stacked on top of each other.',
   },
-  {
+  'three-cols': {
     key: 'three-cols',
     symbol: 'M0 0H1V1H0zM0.33 0V1M0.67 0V1',
     title: 'Three Columns',
-    description: 'Three panes, placed next to each other.',
+    description: 'Three vis, placed next to each other.',
   },
-  {
+  'two-rows-one-right': {
     key: 'two-rows-one-right',
     symbol: 'M0 0H1V1H0zM0 0.5H0.5M0.5 0V1',
     title: 'Two rows, one right',
-    description: 'Three panes, two rows left, one large right.',
+    description: 'Three vis, two rows left, one large right.',
   },
-  {
+  'two-rows-one-left': {
     key: 'two-rows-one-left',
     symbol: 'M0 0H1V1H0zM0.5 0.5H1M0.5 0V1',
     title: 'Two rows, one left',
-    description: 'Three panes, two rows right, one large left.',
+    description: 'Three vis, two rows right, one large left.',
   },
-  {
+  'grid-2x2': {
     key: 'grid-2x2',
     symbol: 'M0 0H1V1H0zM0 0.5H1M0.5 0V1',
     title: '2x2 grid',
-    description: 'Four panes in a 2x2 grid.',
+    description: 'Four visualizations in a 2x2 grid.',
   },
-];
+  'single-vis-content': {
+    key: 'single-vis-content',
+    symbol: 'M0 0H.67V1H0z',
+    contentSymbol: 'M.67 0H1V1H.67Z',
+    title: 'Vis + Content',
+    description: 'Two visualizations, placed next to each other.',
+  } as StoryVisOptionData,
+  'two-cols-content': {
+    key: 'two-cols-content',
+    symbol: 'M0 0H.67V1H0zM.33 0V1M.67 0V1Z',
+    contentSymbol: 'M.67 0H1V1H.67Z',
+    title: 'Three Columns',
+    description: 'Two vis left, one content pane right.',
+  } as StoryVisOptionData,
+  'two-rows-content': {
+    key: 'two-rows-content',
+    symbol: 'M0 0H.67V1H0zM0 .5H.67M.67 0V1Z',
+    contentSymbol: 'M.67 0H1V1H.67Z',
+    title: 'Two Vis + Content',
+    description: 'Two vis left, one content pane right.',
+  } as StoryVisOptionData,
+  'two-contents': {
+    key: 'two-contents',
+    contentSymbol: 'M0 0H1V1H0zM0.5 0V1',
+    title: 'Two Contents',
+    description: 'Two content panes, placed next to each other.',
+  } as StoryVisOptionData,
+};
 
 export interface LayoutButtonProps {
-  onLayoutSelected: (layoutKey: LayoutOptionData['key']) => void;
+  onLayoutSelected: (layoutKey: VisOptionData['key']) => void;
 }
 
 export default function LayoutButton(props: LayoutButtonProps): JSX.Element {
@@ -88,27 +151,28 @@ export default function LayoutButton(props: LayoutButtonProps): JSX.Element {
         return (
           <Fragment>
             <div className="max-h-54 z-50 grid grid-cols-2 gap-4 overflow-y-auto rounded-md bg-white p-4 text-gray-800 drop-shadow-2xl">
-              {layoutOptions.map((option) => {
+              {visLayout.map((option: VisLayout) => {
+                const layout = layoutOptions[option] as LayoutOptionData;
                 return (
                   <button
-                    key={option.key}
+                    key={option}
                     className="grid grid-cols-[3.6rem_1fr] grid-rows-[1.2rem_2.4rem] gap-1 rounded bg-white p-1 hover:bg-slate-100 active:bg-slate-300"
                     onClick={() => {
-                      props.onLayoutSelected(option.key);
+                      props.onLayoutSelected(option);
                       close();
                     }}
                   >
                     <svg className="col-1 row-span-full" viewBox="-0.3 -0.3 1.6 1.6">
                       <path
-                        d={option.symbol}
+                        d={layout.symbol}
                         strokeWidth={0.02}
                         shapeRendering="crispEdges"
                         fill="none"
                         stroke="currentColor"
                       />
                     </svg>
-                    <span className="col-2 row-1 text-left font-semibold">{option.title}</span>
-                    <p className="col-2 row-1 text-left font-light">{option.description ?? ''}</p>
+                    <span className="col-2 row-1 text-left font-semibold">{layout.title}</span>
+                    <p className="col-2 row-1 text-left font-light">{layout.description ?? ''}</p>
                   </button>
                 );
               })}

--- a/src/features/ui/panes.config.ts
+++ b/src/features/ui/panes.config.ts
@@ -1,7 +1,7 @@
 export const leftPaneProps = {
   minSize: 250,
   maxSize: 600,
-  preferredSize: '25%',
+  preferredSize: '15%',
   /* className: 'grid', */
 };
 export const centerPaneProps = { minSize: 250, preferredSize: '50%', className: 'grid' };
@@ -9,6 +9,6 @@ export const disclosurePaneProps = { minSize: 28 };
 export const rightPaneProps = {
   minSize: 250,
   maxSize: 600,
-  preferredSize: '25%',
+  preferredSize: '15%',
   /* className: 'grid', */
 };

--- a/src/features/visualization-layouts/visualization-container.tsx
+++ b/src/features/visualization-layouts/visualization-container.tsx
@@ -1,0 +1,50 @@
+import { AdjustmentsIcon } from '@heroicons/react/outline';
+import { XIcon } from '@heroicons/react/solid';
+
+import { useAppDispatch } from '@/app/store';
+import type { Visualization } from '@/features/common/visualization.slice';
+import Button from '@/features/ui/Button';
+import type { SlotId, Workspace } from '@/features/visualization-layouts/workspaces.slice';
+import { releaseVisualizationForVisualizationSlotForCurrentWorkspace } from '@/features/visualization-layouts/workspaces.slice';
+
+interface VisualisationContainerProps {
+  workspaceId: Workspace['id'];
+  visualizationSlot: SlotId;
+  id: Visualization['id'] | null;
+}
+
+export default function VisualisationContainer(props: VisualisationContainerProps): JSX.Element {
+  const { visualizationSlot, id } = props;
+  const dispatch = useAppDispatch();
+  //TODO: HeaderArea with Icons
+  //TODO: VisualisatinArea
+
+  //TODO getVisualization for Slot for Current Workspace
+
+  function onReleaseVisualizationSlot() {
+    dispatch(releaseVisualizationForVisualizationSlotForCurrentWorkspace(visualizationSlot));
+  }
+
+  return (
+    <div className="grid h-full w-full grid-rows-[auto_1fr]">
+      <div className="flex flex-row flex-nowrap justify-between gap-2 truncate bg-indigo-800 px-2 py-1 text-white">
+        <div className="truncate">Visualization Container for: {id}</div>
+        <div className="sticky right-0 flex flex-nowrap gap-1">
+          <Button className="ml-auto grow-0" shadow="none" size="extra-small" round="circle">
+            <AdjustmentsIcon className="h-3 w-3" />
+          </Button>
+          <Button
+            className="ml-auto grow-0"
+            shadow="none"
+            size="extra-small"
+            round="circle"
+            onClick={onReleaseVisualizationSlot}
+          >
+            <XIcon className="h-3 w-3" />
+          </Button>
+        </div>
+      </div>
+      <div className="relative h-full w-full bg-red-100">{/* <GeoMap {...baseMap} /> */}</div>
+    </div>
+  );
+}

--- a/src/features/visualization-layouts/visualization-container.tsx
+++ b/src/features/visualization-layouts/visualization-container.tsx
@@ -126,7 +126,7 @@ export default function VisualisationContainer(props: VisualisationContainerProp
         </div>
       </div>
       {visualization !== undefined && (
-        <div className="bg-red-100">{<VisualisationComponent visualization={visualization} />}</div>
+        <div>{<VisualisationComponent visualization={visualization} />}</div>
       )}
     </div>
   );

--- a/src/features/visualization-layouts/visualization-container.tsx
+++ b/src/features/visualization-layouts/visualization-container.tsx
@@ -1,36 +1,113 @@
 import { AdjustmentsIcon } from '@heroicons/react/outline';
 import { XIcon } from '@heroicons/react/solid';
+import type { DragEvent } from 'react';
 
-import { useAppDispatch } from '@/app/store';
+import { useAppDispatch, useAppSelector } from '@/app/store';
+import type { EntityEvent, Person } from '@/features/common/entity.model';
 import type { Visualization } from '@/features/common/visualization.slice';
+import {
+  addEventToVisualization,
+  addPersonToVisualization,
+  selectAllVisualizations,
+} from '@/features/common/visualization.slice';
 import Button from '@/features/ui/Button';
-import type { SlotId, Workspace } from '@/features/visualization-layouts/workspaces.slice';
-import { releaseVisualizationForVisualizationSlotForCurrentWorkspace } from '@/features/visualization-layouts/workspaces.slice';
+import VisualisationComponent from '@/features/visualization-layouts/visualization';
+import type { SlotId } from '@/features/visualization-layouts/workspaces.slice';
 
 interface VisualisationContainerProps {
-  workspaceId: Workspace['id'];
   visualizationSlot: SlotId;
   id: Visualization['id'] | null;
+  onReleaseVisualization: (visSlot: string, visId: string) => void;
+  onSwitchVisualization: (
+    targetSlot: string,
+    targetVis: string | null,
+    soruceSlot: string,
+    sourceVis: string | null,
+  ) => void;
+  setEditElement?: (editElement: any) => void;
+  setOpenDialog: (openDialog: boolean) => void;
 }
 
 export default function VisualisationContainer(props: VisualisationContainerProps): JSX.Element {
-  const { visualizationSlot, id } = props;
+  const {
+    visualizationSlot,
+    id,
+    onReleaseVisualization,
+    onSwitchVisualization,
+    setOpenDialog,
+    setEditElement,
+  } = props;
+
   const dispatch = useAppDispatch();
-  //TODO: HeaderArea with Icons
-  //TODO: VisualisatinArea
 
-  //TODO getVisualization for Slot for Current Workspace
+  const allVisualizations = useAppSelector(selectAllVisualizations);
 
-  function onReleaseVisualizationSlot() {
-    dispatch(releaseVisualizationForVisualizationSlotForCurrentWorkspace(visualizationSlot));
-  }
+  const visualization = Object.values(allVisualizations).filter((vis: Visualization) => {
+    return vis.id === id;
+  })[0];
+
+  const allowDrop = (event: DragEvent) => {
+    event.preventDefault();
+  };
+
+  const drop = (event: DragEvent) => {
+    event.preventDefault();
+    const data = JSON.parse(event.dataTransfer.getData('Text'));
+
+    switch (data.type) {
+      case 'visualization':
+        onSwitchVisualization(visualizationSlot, data.props.id, data.parent, id);
+        break;
+      case 'Person':
+        dispatch(
+          addPersonToVisualization({ visId: visualization!.id, person: data.props as Person }),
+        );
+        break;
+      case 'Event':
+        dispatch(
+          addEventToVisualization({ visId: visualization!.id, event: data.props as EntityEvent }),
+        );
+        break;
+      default:
+        break;
+    }
+  };
 
   return (
-    <div className="grid h-full w-full grid-rows-[auto_1fr]">
-      <div className="flex flex-row flex-nowrap justify-between gap-2 truncate bg-indigo-800 px-2 py-1 text-white">
+    <div
+      className="grid h-full w-full cursor-grabbing grid-rows-[29px_1fr]"
+      onDrop={drop}
+      onDragOver={allowDrop}
+    >
+      <div
+        className="flex flex-row flex-nowrap justify-between gap-2 truncate bg-indigo-800 px-2 py-1 text-white"
+        draggable={true}
+        onDragStart={(event) => {
+          return event.dataTransfer.setData(
+            'Text',
+            JSON.stringify({
+              type: 'visualization',
+              props: visualization,
+              parent: visualizationSlot,
+              content: '',
+            }),
+          );
+        }}
+      >
         <div className="truncate">Visualization Container for: {id}</div>
         <div className="sticky right-0 flex flex-nowrap gap-1">
-          <Button className="ml-auto grow-0" shadow="none" size="extra-small" round="circle">
+          <Button
+            className="ml-auto grow-0"
+            shadow="none"
+            size="extra-small"
+            round="circle"
+            onClick={() => {
+              if (setEditElement !== undefined) {
+                setEditElement(visualization);
+                setOpenDialog(true);
+              }
+            }}
+          >
             <AdjustmentsIcon className="h-3 w-3" />
           </Button>
           <Button
@@ -38,13 +115,19 @@ export default function VisualisationContainer(props: VisualisationContainerProp
             shadow="none"
             size="extra-small"
             round="circle"
-            onClick={onReleaseVisualizationSlot}
+            onClick={() => {
+              if (id !== null) {
+                onReleaseVisualization(visualizationSlot, id);
+              }
+            }}
           >
             <XIcon className="h-3 w-3" />
           </Button>
         </div>
       </div>
-      <div className="relative h-full w-full bg-red-100">{/* <GeoMap {...baseMap} /> */}</div>
+      {visualization !== undefined && (
+        <div className="bg-red-100">{<VisualisationComponent visualization={visualization} />}</div>
+      )}
     </div>
   );
 }

--- a/src/features/visualization-layouts/visualization-group.tsx
+++ b/src/features/visualization-layouts/visualization-group.tsx
@@ -1,0 +1,102 @@
+import { Allotment } from 'allotment';
+import { Fragment } from 'react';
+
+import VisualizationContainer from '@/features/visualization-layouts/visualization-container';
+import type { SlotId, Workspace } from '@/features/visualization-layouts/workspaces.slice';
+import VisualizationWizard from '@/features/visualization-wizard/visualization-wizard';
+
+interface VisualisationGroupProps {
+  workspace: Workspace;
+}
+
+interface LayoutPaneContent {
+  content: string;
+}
+
+interface LayoutRow {
+  rows: Array<LayoutCol | LayoutPaneContent>;
+}
+
+interface LayoutCol {
+  cols: Array<LayoutPaneContent | LayoutRow>;
+}
+
+type LayoutTemplateItem = LayoutCol | LayoutPaneContent | LayoutRow;
+
+const layoutTemplates: Record<string, LayoutTemplateItem> = {
+  'single-pane': { rows: [{ content: 'vis-1' }] },
+  'two-rows': { rows: [{ content: 'vis-1' }, { content: 'vis-2' }] },
+  'two-cols': { cols: [{ content: 'vis-1' }, { content: 'vis-2' }] },
+  'three-rows': { rows: [{ content: 'vis-1' }, { content: 'vis-2' }, { content: 'vis-3' }] },
+  'three-cols': { cols: [{ content: 'vis-1' }, { content: 'vis-2' }, { content: 'vis-3' }] },
+  'two-rows-one-right': {
+    cols: [{ rows: [{ content: 'vis-1' }, { content: 'vis-2' }] }, { content: 'vis-3' }],
+  },
+  'two-rows-one-left': {
+    cols: [{ content: 'vis-1' }, { rows: [{ content: 'vis-2' }, { content: 'vis-3' }] }],
+  },
+  'two-cols-one-bottom': {
+    rows: [{ cols: [{ content: 'vis-1' }, { content: 'vis-2' }] }, { content: 'vis-3' }],
+  },
+  'two-cols-one-top': {
+    rows: [{ content: 'vis-1' }, { cols: [{ content: 'vis-2' }, { content: 'vis-3' }] }],
+  },
+  // FIXME: remove grid-2x2; equals grid-2x2-cols
+  'grid-2x2': {
+    cols: [
+      { rows: [{ content: 'vis-1' }, { content: 'vis-2' }] },
+      { rows: [{ content: 'vis-3' }, { content: 'vis-4' }] },
+    ],
+  },
+  'grid-2x2-cols': {
+    cols: [
+      { rows: [{ content: 'vis-1' }, { content: 'vis-2' }] },
+      { rows: [{ content: 'vis-3' }, { content: 'vis-4' }] },
+    ],
+  },
+  'grid-2x2-rows': {
+    rows: [
+      { cols: [{ content: 'vis-1' }, { content: 'vis-2' }] },
+      { cols: [{ content: 'vis-3' }, { content: 'vis-4' }] },
+    ],
+  },
+};
+
+export default function VisualisationGroup(props: VisualisationGroupProps): JSX.Element {
+  const { workspace } = props;
+  const layout = workspace.layoutOption;
+  console.log(layout, layoutTemplates[layout]);
+  const selectedLayout = layoutTemplates[layout] as LayoutTemplateItem;
+
+  const generateLayout = (layoutTemplate: LayoutTemplateItem) => {
+    for (const [key, value] of Object.entries(layoutTemplate)) {
+      console.log(`${key}: ${value}`);
+      if (key === 'cols' || key === 'rows') {
+        return (
+          <Allotment
+            key={`alottment-${key}-${key === 'cols' ? false : true}`}
+            vertical={key === 'cols' ? false : true}
+          >
+            {value.map((item: LayoutTemplateItem, index: number) => {
+              return <Allotment.Pane key={`${index}`}>{generateLayout(item)}</Allotment.Pane>;
+            })}
+          </Allotment>
+        );
+      } else if (key === 'content') {
+        if (workspace.visualizationSlots[value as SlotId] !== null) {
+          return (
+            <VisualizationContainer
+              workspaceId={workspace.id}
+              visualizationSlot={value}
+              id={workspace.visualizationSlots[value as SlotId]}
+            />
+          );
+        } else {
+          return <VisualizationWizard visualizationSlot={value} />;
+        }
+      }
+    }
+  };
+
+  return <Fragment>{generateLayout(selectedLayout)}</Fragment>;
+}

--- a/src/features/visualization-layouts/visualization.tsx
+++ b/src/features/visualization-layouts/visualization.tsx
@@ -1,0 +1,74 @@
+import { Fragment } from 'react';
+
+import { useAppSelector } from '@/app/store';
+import { selectEntitiesByKind } from '@/features/common/entities.slice';
+import type { EntityEvent } from '@/features/common/entity.model';
+import type { Visualization } from '@/features/common/visualization.slice';
+import { GeoMap } from '@/features/geomap/geo-map';
+import { StoryTimeline } from '@/features/storycreator/story-timeline';
+import { StoryMapComponent } from '@/features/storycreator/StoryMap';
+import { Timeline } from '@/features/timeline/timeline';
+
+interface VisualizationProps {
+  visualization: Visualization;
+}
+
+export default function VisualisationComponent(props: VisualizationProps): JSX.Element {
+  const { visualization } = props;
+
+  const entitiesByKind = useAppSelector(selectEntitiesByKind);
+  const allPersons = Object.values(entitiesByKind.person);
+
+  const events = visualization.eventIds;
+  const persons = visualization.entityIds;
+
+  const filteredPersons =
+    persons.length > 0
+      ? allPersons.filter((person) => {
+          return persons.includes(person.id);
+        })
+      : [];
+
+  const personEvents = filteredPersons.flatMap((person) => {
+    return person.history as Array<EntityEvent>;
+  });
+  const allPersonEvents = allPersons.flatMap((person) => {
+    return person.history as Array<EntityEvent>;
+  });
+
+  const filteredEvents =
+    events.length > 0
+      ? allPersonEvents.filter((historyEvent: EntityEvent) => {
+          return events.includes(historyEvent.id);
+        })
+      : [];
+
+  const visEvents = [...personEvents, ...filteredEvents];
+
+  const targetIds = filteredEvents.map((event) => {
+    return event.targetId;
+  });
+
+  const twiceFilteredPersons = filteredPersons.filter((person) => {
+    return targetIds.includes(person.id);
+  });
+
+  const visPersons = [...filteredPersons, ...twiceFilteredPersons];
+
+  const generateVisualization = (visualization: Visualization) => {
+    switch (visualization.type) {
+      case 'map':
+        return <GeoMap />;
+      case 'story-map':
+        return <StoryMapComponent events={visEvents} />;
+      case 'timeline':
+        return <Timeline />;
+      case 'story-timeline':
+        return <StoryTimeline persons={visPersons} events={visEvents} />;
+      default:
+        return <div>{`Wrong type of visualization ${visualization.type}!`}</div>;
+    }
+  };
+
+  return <Fragment>{generateVisualization(visualization)}</Fragment>;
+}

--- a/src/features/visualization-layouts/visualization.tsx
+++ b/src/features/visualization-layouts/visualization.tsx
@@ -22,6 +22,8 @@ export default function VisualisationComponent(props: VisualizationProps): JSX.E
   const events = visualization.eventIds;
   const persons = visualization.entityIds;
 
+  console.log(events, persons);
+
   const filteredPersons =
     persons.length > 0
       ? allPersons.filter((person) => {
@@ -29,12 +31,18 @@ export default function VisualisationComponent(props: VisualizationProps): JSX.E
         })
       : [];
 
+  console.log('filteredPersons', filteredPersons);
+
   const personEvents = filteredPersons.flatMap((person) => {
     return person.history as Array<EntityEvent>;
   });
   const allPersonEvents = allPersons.flatMap((person) => {
     return person.history as Array<EntityEvent>;
   });
+
+  console.log('allPersonEvents', allPersonEvents);
+  console.log('personEvents', personEvents);
+  console.log('events', events);
 
   const filteredEvents =
     events.length > 0
@@ -45,15 +53,20 @@ export default function VisualisationComponent(props: VisualizationProps): JSX.E
 
   const visEvents = [...personEvents, ...filteredEvents];
 
+  console.log('filteredEvents', filteredEvents);
   const targetIds = filteredEvents.map((event) => {
     return event.targetId;
   });
 
-  const twiceFilteredPersons = filteredPersons.filter((person) => {
+  console.log('targetIds', targetIds);
+
+  const twiceFilteredPersons = allPersons.filter((person) => {
     return targetIds.includes(person.id);
   });
 
   const visPersons = [...filteredPersons, ...twiceFilteredPersons];
+
+  console.log('twiceFilteredPersons', twiceFilteredPersons);
 
   const generateVisualization = (visualization: Visualization) => {
     switch (visualization.type) {

--- a/src/features/visualization-layouts/workspaces.slice.ts
+++ b/src/features/visualization-layouts/workspaces.slice.ts
@@ -25,7 +25,7 @@ const initialState: Workspaces = {
     {
       id: 'workspace-1',
       label: 'Visualisierung 1',
-      layoutOption: 'single-pane',
+      layoutOption: 'single-vis',
       visualizationSlots: { 'vis-1': null, 'vis-2': null, 'vis-3': null, 'vis-4': null },
     },
   ],
@@ -76,6 +76,11 @@ const workspacesSlice = createSlice({
       const visualizationSlot = action.payload as SlotId;
       state.workspaces[state.currentWorkspace]!.visualizationSlots[visualizationSlot] = null;
     },
+    switchVisualizationsInWorkspace: (state, action) => {
+      const { targetSlot, targetVis, sourceSlot, sourceVis, workspace } = action.payload;
+      state.workspaces[workspace]!.visualizationSlots[targetSlot as SlotId] = targetVis;
+      state.workspaces[workspace]!.visualizationSlots[sourceSlot as SlotId] = sourceVis;
+    },
   },
 });
 
@@ -86,6 +91,7 @@ export const {
   setLayoutForCurrentWorkspace,
   setVisualizationForVisualizationSlotForCurrentWorkspace,
   releaseVisualizationForVisualizationSlotForCurrentWorkspace,
+  switchVisualizationsInWorkspace,
 } = workspacesSlice.actions;
 
 export const selectAllWorkspaces = (state: RootState) => {

--- a/src/features/visualization-layouts/workspaces.slice.ts
+++ b/src/features/visualization-layouts/workspaces.slice.ts
@@ -1,0 +1,95 @@
+import type { PayloadAction } from '@reduxjs/toolkit';
+import { createSlice } from '@reduxjs/toolkit';
+
+import type { RootState } from '@/app/store';
+import type { Visualization } from '@/features/common/visualization.slice';
+import type { LayoutOptionData } from '@/features/ui/analyse-page-toolbar/layout-popover';
+
+export type SlotId = 'vis-1' | 'vis-2' | 'vis-3' | 'vis-4';
+
+export interface Workspace {
+  id: string;
+  label: string;
+  layoutOption: LayoutOptionData['key'];
+  visualizationSlots: Record<SlotId, Visualization['id'] | null>;
+}
+
+interface Workspaces {
+  currentWorkspace: number;
+  workspaces: Array<Workspace>;
+}
+
+const initialState: Workspaces = {
+  currentWorkspace: 0,
+  workspaces: [
+    {
+      id: 'workspace-1',
+      label: 'Visualisierung 1',
+      layoutOption: 'single-pane',
+      visualizationSlots: { 'vis-1': null, 'vis-2': null, 'vis-3': null, 'vis-4': null },
+    },
+  ],
+};
+
+const workspacesSlice = createSlice({
+  name: 'workspaces',
+  initialState,
+  reducers: {
+    addWorkspace: (state, action: PayloadAction<Workspace>) => {
+      const workspace = action.payload;
+      workspace['id'] = `workspace-${Math.random()
+        .toString(36)
+        .replace(/[^a-z]+/g, '')
+        .substring(0, 4)}`;
+      state.workspaces.push(workspace);
+      state.currentWorkspace = state.workspaces.length - 1;
+    },
+    resetWorkspaces() {
+      return initialState;
+    },
+    removeWorkspace: (state, action: PayloadAction<Workspaces['currentWorkspace']>) => {
+      const removeIndex = action.payload;
+      const count = state.workspaces.length;
+      state.workspaces.splice(removeIndex, 1);
+      state.currentWorkspace = Math.max(removeIndex - 1, 0);
+
+      if (count === 1) {
+        state.currentWorkspace = 0;
+        state.workspaces = initialState.workspaces;
+      }
+    },
+    setCurrentWorkspace: (state, action: PayloadAction<Workspaces['currentWorkspace']>) => {
+      const currentWorkspace = action.payload;
+      state.currentWorkspace = currentWorkspace;
+    },
+    setLayoutForCurrentWorkspace: (state, action: PayloadAction<Workspace['layoutOption']>) => {
+      const layoutOption = action.payload;
+      state.workspaces[state.currentWorkspace]!.layoutOption = layoutOption;
+    },
+    setVisualizationForVisualizationSlotForCurrentWorkspace: (state, action) => {
+      const visualizationSlot = action.payload.visualizationSlot as SlotId;
+      const visualizationId = action.payload.visualizationId as Visualization['id'];
+      state.workspaces[state.currentWorkspace]!.visualizationSlots[visualizationSlot] =
+        visualizationId;
+    },
+    releaseVisualizationForVisualizationSlotForCurrentWorkspace: (state, action) => {
+      const visualizationSlot = action.payload as SlotId;
+      state.workspaces[state.currentWorkspace]!.visualizationSlots[visualizationSlot] = null;
+    },
+  },
+});
+
+export const {
+  addWorkspace,
+  removeWorkspace,
+  setCurrentWorkspace,
+  setLayoutForCurrentWorkspace,
+  setVisualizationForVisualizationSlotForCurrentWorkspace,
+  releaseVisualizationForVisualizationSlotForCurrentWorkspace,
+} = workspacesSlice.actions;
+
+export const selectAllWorkspaces = (state: RootState) => {
+  return state.workspaces;
+};
+
+export default workspacesSlice.reducer;

--- a/src/features/visualization-layouts/workspaces.tsx
+++ b/src/features/visualization-layouts/workspaces.tsx
@@ -4,15 +4,21 @@ import {
   XIcon as CloseWorkspaceIcon,
 } from '@heroicons/react/outline';
 import { clsx } from 'clsx';
+import { useState } from 'react';
 
 import { useAppDispatch, useAppSelector } from '@/app/store';
+import { StoryContentDialog } from '@/features/storycreator/StoryContentDialog';
+import type { PanelLayout } from '@/features/ui/analyse-page-toolbar/layout-popover';
 import Button from '@/features/ui/Button';
 import VisualizationGroup from '@/features/visualization-layouts/visualization-group';
 import {
   addWorkspace,
+  releaseVisualizationForVisualizationSlotForCurrentWorkspace,
   removeWorkspace,
   selectAllWorkspaces,
   setCurrentWorkspace,
+  setVisualizationForVisualizationSlotForCurrentWorkspace,
+  switchVisualizationsInWorkspace,
 } from '@/features/visualization-layouts/workspaces.slice';
 
 export default function Workspaces(): JSX.Element {
@@ -29,7 +35,7 @@ export default function Workspaces(): JSX.Element {
       addWorkspace({
         id: '',
         label: 'Visualisation',
-        layoutOption: 'single-pane',
+        layoutOption: 'single-vis',
         visualizationSlots: { 'vis-1': null, 'vis-2': null, 'vis-3': null, 'vis-4': null },
       }),
     );
@@ -39,68 +45,125 @@ export default function Workspaces(): JSX.Element {
     dispatch(removeWorkspace(id));
   }
 
+  const onSwitchVisualization = (
+    targetSlot: string,
+    targetVis: string | null,
+    sourceSlot: string,
+    sourceVis: string | null,
+  ) => {
+    dispatch(
+      switchVisualizationsInWorkspace({
+        targetSlot,
+        targetVis,
+        sourceSlot,
+        sourceVis,
+        workspace: workspaces.currentWorkspace,
+      }),
+    );
+  };
+
+  const handleClose = () => {
+    setOpenDialog(false);
+  };
+
+  const handleSave = (element: any) => {
+    /* dispatch(editSlideContent({ slide: slide, content: element })); */
+    console.log('SAVED!', element);
+  };
+
+  const [openDialog, setOpenDialog] = useState(false);
+
+  const [editElement, setEditElement] = useState<any | null>(null);
+
   return (
-    <Tab.Group
-      selectedIndex={workspaces.currentWorkspace}
-      onChange={onChangeWorkspace}
-      defaultIndex={0}
-    >
-      <Tab.Panels className="h-full w-full grow bg-indigo-300">
-        {workspaces.workspaces.map((workspace, idx) => {
-          return (
-            <Tab.Panel key={idx} className="h-full w-full p-0">
-              <VisualizationGroup workspace={workspace} />
-            </Tab.Panel>
-          );
-        })}
-      </Tab.Panels>
-      <Tab.List className="flex grow-0 space-x-1 bg-blue-900 p-1">
-        {workspaces.workspaces.map((workspace, idx) => {
-          return (
-            <Tab
-              key={workspace.id}
-              className={({ selected }) => {
-                return clsx({
-                  ['rounded-sm py-1 px-2 text-sm font-medium leading-5 text-blue-700']: true, //always applies
-                  ['bg-white shadow']: selected, //only when open === true
-                  ['text-blue-100 hover:bg-white/[0.12] hover:text-white']: !selected,
-                });
-              }}
-            >
-              {({ selected }) => {
-                return selected ? (
-                  <div className="flex gap-2">
-                    {workspace.label}
-                    <Button
-                      shadow="none"
-                      size="extra-small"
-                      round="circle"
-                      onClick={() => {
-                        return onRemoveWorkspace(idx);
-                      }}
-                    >
-                      <CloseWorkspaceIcon className="h-3 w-3" />
-                    </Button>
-                  </div>
-                ) : (
-                  workspace.label
-                );
-              }}
-            </Tab>
-          );
-        })}
-        <div className="grow"></div>
-        <Button
-          className="ml-auto grow-0"
-          shadow="none"
-          size="small"
-          round="circle"
-          color="accent"
-          onClick={onAddWorkspace}
-        >
-          <AddWorkspaceIcon className="h-5 w-5" />
-        </Button>
-      </Tab.List>
-    </Tab.Group>
+    <>
+      <Tab.Group
+        selectedIndex={workspaces.currentWorkspace}
+        onChange={onChangeWorkspace}
+        defaultIndex={0}
+      >
+        <Tab.Panels className="h-full w-full grow bg-indigo-300">
+          {workspaces.workspaces.map((workspace, idx) => {
+            return (
+              <Tab.Panel key={idx} className="h-full w-full p-0">
+                <VisualizationGroup
+                  layout={workspace.layoutOption as PanelLayout}
+                  visualizationSlots={workspace.visualizationSlots}
+                  onAddVisualization={(visSlot: string, visId: string) => {
+                    dispatch(
+                      setVisualizationForVisualizationSlotForCurrentWorkspace({
+                        visualizationSlot: visSlot,
+                        visualizationId: visId,
+                      }),
+                    );
+                  }}
+                  onReleaseVisualization={(visSlot: string) => {
+                    dispatch(releaseVisualizationForVisualizationSlotForCurrentWorkspace(visSlot));
+                  }}
+                  onSwitchVisualization={onSwitchVisualization}
+                  setEditVisualizationElement={setEditElement}
+                  setOpenDialog={setOpenDialog}
+                />
+              </Tab.Panel>
+            );
+          })}
+        </Tab.Panels>
+        <Tab.List className="flex grow-0 space-x-1 bg-blue-900 p-1">
+          {workspaces.workspaces.map((workspace, idx) => {
+            return (
+              <Tab
+                key={workspace.id}
+                className={({ selected }) => {
+                  return clsx({
+                    ['rounded-sm py-1 px-2 text-sm font-medium leading-5 text-blue-700']: true, //always applies
+                    ['bg-white shadow']: selected, //only when open === true
+                    ['text-blue-100 hover:bg-white/[0.12] hover:text-white']: !selected,
+                  });
+                }}
+              >
+                {({ selected }) => {
+                  return selected ? (
+                    <div className="flex gap-2">
+                      {workspace.label}
+                      <Button
+                        shadow="none"
+                        size="extra-small"
+                        round="circle"
+                        onClick={() => {
+                          return onRemoveWorkspace(idx);
+                        }}
+                      >
+                        <CloseWorkspaceIcon className="h-3 w-3" />
+                      </Button>
+                    </div>
+                  ) : (
+                    workspace.label
+                  );
+                }}
+              </Tab>
+            );
+          })}
+          <div className="grow"></div>
+          <Button
+            className="ml-auto grow-0"
+            shadow="none"
+            size="small"
+            round="circle"
+            color="accent"
+            onClick={onAddWorkspace}
+          >
+            <AddWorkspaceIcon className="h-5 w-5" />
+          </Button>
+        </Tab.List>
+      </Tab.Group>
+      {editElement != null && (
+        <StoryContentDialog
+          open={openDialog}
+          onClose={handleClose}
+          element={editElement}
+          onSave={handleSave}
+        />
+      )}
+    </>
   );
 }

--- a/src/features/visualization-layouts/workspaces.tsx
+++ b/src/features/visualization-layouts/workspaces.tsx
@@ -1,0 +1,106 @@
+import { Tab } from '@headlessui/react';
+import {
+  DocumentAddIcon as AddWorkspaceIcon,
+  XIcon as CloseWorkspaceIcon,
+} from '@heroicons/react/outline';
+import { clsx } from 'clsx';
+
+import { useAppDispatch, useAppSelector } from '@/app/store';
+import Button from '@/features/ui/Button';
+import VisualizationGroup from '@/features/visualization-layouts/visualization-group';
+import {
+  addWorkspace,
+  removeWorkspace,
+  selectAllWorkspaces,
+  setCurrentWorkspace,
+} from '@/features/visualization-layouts/workspaces.slice';
+
+export default function Workspaces(): JSX.Element {
+  const dispatch = useAppDispatch();
+  const workspaces = useAppSelector(selectAllWorkspaces);
+
+  function onChangeWorkspace(id: number) {
+    dispatch(setCurrentWorkspace(id));
+  }
+
+  function onAddWorkspace() {
+    dispatch(
+      //FIXME get template from config (not in store, because can be used to programmatically add a preconfigured workspace)
+      addWorkspace({
+        id: '',
+        label: 'Visualisation',
+        layoutOption: 'single-pane',
+        visualizationSlots: { 'vis-1': null, 'vis-2': null, 'vis-3': null, 'vis-4': null },
+      }),
+    );
+  }
+
+  function onRemoveWorkspace(id: number) {
+    dispatch(removeWorkspace(id));
+  }
+
+  return (
+    <Tab.Group
+      selectedIndex={workspaces.currentWorkspace}
+      onChange={onChangeWorkspace}
+      defaultIndex={0}
+    >
+      <Tab.Panels className="h-full w-full grow bg-indigo-300">
+        {workspaces.workspaces.map((workspace, idx) => {
+          return (
+            <Tab.Panel key={idx} className="h-full w-full p-0">
+              <VisualizationGroup workspace={workspace} />
+            </Tab.Panel>
+          );
+        })}
+      </Tab.Panels>
+      <Tab.List className="flex grow-0 space-x-1 bg-blue-900 p-1">
+        {workspaces.workspaces.map((workspace, idx) => {
+          return (
+            <Tab
+              key={workspace.id}
+              className={({ selected }) => {
+                return clsx({
+                  ['rounded-sm py-1 px-2 text-sm font-medium leading-5 text-blue-700']: true, //always applies
+                  ['bg-white shadow']: selected, //only when open === true
+                  ['text-blue-100 hover:bg-white/[0.12] hover:text-white']: !selected,
+                });
+              }}
+            >
+              {({ selected }) => {
+                return selected ? (
+                  <div className="flex gap-2">
+                    {workspace.label}
+                    <Button
+                      shadow="none"
+                      size="extra-small"
+                      round="circle"
+                      onClick={() => {
+                        return onRemoveWorkspace(idx);
+                      }}
+                    >
+                      <CloseWorkspaceIcon className="h-3 w-3" />
+                    </Button>
+                  </div>
+                ) : (
+                  workspace.label
+                );
+              }}
+            </Tab>
+          );
+        })}
+        <div className="grow"></div>
+        <Button
+          className="ml-auto grow-0"
+          shadow="none"
+          size="small"
+          round="circle"
+          color="accent"
+          onClick={onAddWorkspace}
+        >
+          <AddWorkspaceIcon className="h-5 w-5" />
+        </Button>
+      </Tab.List>
+    </Tab.Group>
+  );
+}

--- a/src/features/visualization-wizard/visualization-wizard.tsx
+++ b/src/features/visualization-wizard/visualization-wizard.tsx
@@ -1,43 +1,113 @@
 import { useAppDispatch } from '@/app/store';
+import type { Visualization } from '@/features/common/visualization.slice';
 import { createVisualization } from '@/features/common/visualization.slice';
 import Button from '@/features/ui/Button';
 import type { SlotId } from '@/features/visualization-layouts/workspaces.slice';
-import { setVisualizationForVisualizationSlotForCurrentWorkspace } from '@/features/visualization-layouts/workspaces.slice';
 
 interface VisualizationWizardProps {
   visualizationSlot: SlotId;
+  onAddVisualization: (visualizationSlot: string, visId: string) => void;
 }
 export default function VisualizationWizard(props: VisualizationWizardProps): JSX.Element {
-  const { visualizationSlot } = props;
+  const { visualizationSlot, onAddVisualization } = props;
   const dispatch = useAppDispatch();
 
-  function onAddVisualization() {
+  function createVis(type: Visualization['type']) {
     const visId = `visualization-${Math.random()
       .toString(36)
       .replace(/[^a-z]+/g, '')
       .substring(0, 4)}`;
-    // dispatch();
     //TODO dispatch -> createVisualisation -> common/visualization.slice
     dispatch(
       createVisualization({
         id: visId,
-        type: 'map',
+        type: type,
         name: visId,
         entityIds: [],
         eventIds: [],
         props: {},
       }),
     );
-    dispatch(
-      setVisualizationForVisualizationSlotForCurrentWorkspace({
-        visualizationSlot: visualizationSlot,
-        visualizationId: visId,
-      }),
-    );
+
+    return visId;
+  }
+
+  /* function onAddVisualization() {
+    if (slide !== undefined) {
+      dispatch(
+        setVisualizationForVisualizationSlotForStorySlide({
+          slide: slide,
+          visualizationSlot: visualizationSlot,
+          visualizationId: visId,
+        }),
+      );
+    } else {
+      dispatch(
+        setVisualizationForVisualizationSlotForCurrentWorkspace({
+          visualizationSlot: visualizationSlot,
+          visualizationId: visId,
+        }),
+      );
+    }
+  } */
+
+  function onButtonClick(type: Visualization['type']) {
+    const visId = createVis(type);
+    onAddVisualization(visualizationSlot, visId);
   }
 
   return (
-    <Button
+    <div className="flex h-full w-full items-center justify-center p-5">
+      <div className="grid grid-cols-2 gap-2">
+        <Button
+          round="round"
+          color="accent"
+          onClick={() => {
+            onButtonClick('map');
+          }}
+        >
+          Map
+        </Button>
+        <Button
+          round="round"
+          color="accent"
+          onClick={() => {
+            onButtonClick('story-map');
+          }}
+        >
+          Story-Map
+        </Button>
+        <Button
+          round="round"
+          color="accent"
+          onClick={() => {
+            onButtonClick('timeline');
+          }}
+        >
+          Timeline
+        </Button>
+        <Button
+          round="round"
+          color="accent"
+          onClick={() => {
+            onButtonClick('story-timeline');
+          }}
+        >
+          Story-Timeline
+        </Button>
+        <Button round="round" color="accent">
+          Set
+        </Button>
+        <Button round="round" color="accent">
+          Hierarchy
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+{
+  /* <Button
       size="small"
       color="warning"
       round="round"
@@ -45,6 +115,5 @@ export default function VisualizationWizard(props: VisualizationWizardProps): JS
       className="ml-auto self-end"
     >
       Add Visualization
-    </Button>
-  );
+    </Button> */
 }

--- a/src/features/visualization-wizard/visualization-wizard.tsx
+++ b/src/features/visualization-wizard/visualization-wizard.tsx
@@ -1,0 +1,50 @@
+import { useAppDispatch } from '@/app/store';
+import { createVisualization } from '@/features/common/visualization.slice';
+import Button from '@/features/ui/Button';
+import type { SlotId } from '@/features/visualization-layouts/workspaces.slice';
+import { setVisualizationForVisualizationSlotForCurrentWorkspace } from '@/features/visualization-layouts/workspaces.slice';
+
+interface VisualizationWizardProps {
+  visualizationSlot: SlotId;
+}
+export default function VisualizationWizard(props: VisualizationWizardProps): JSX.Element {
+  const { visualizationSlot } = props;
+  const dispatch = useAppDispatch();
+
+  function onAddVisualization() {
+    const visId = `visualization-${Math.random()
+      .toString(36)
+      .replace(/[^a-z]+/g, '')
+      .substring(0, 4)}`;
+    // dispatch();
+    //TODO dispatch -> createVisualisation -> common/visualization.slice
+    dispatch(
+      createVisualization({
+        id: visId,
+        type: 'map',
+        name: visId,
+        entityIds: [],
+        eventIds: [],
+        props: {},
+      }),
+    );
+    dispatch(
+      setVisualizationForVisualizationSlotForCurrentWorkspace({
+        visualizationSlot: visualizationSlot,
+        visualizationId: visId,
+      }),
+    );
+  }
+
+  return (
+    <Button
+      size="small"
+      color="warning"
+      round="round"
+      onClick={onAddVisualization}
+      className="ml-auto self-end"
+    >
+      Add Visualization
+    </Button>
+  );
+}

--- a/src/mocks/db.ts
+++ b/src/mocks/db.ts
@@ -44,7 +44,11 @@ function createTable<T extends Entity>() {
       if (entity.history == null) {
         entity.history = [];
       }
-      const newRelation = { ...relation, targetId: id.toString() } as EntityEvent;
+      const newRelation = {
+        ...relation,
+        targetId: id.toString(),
+        id: faker.datatype.uuid(),
+      } as EntityEvent;
 
       entity.history.push(newRelation);
     },
@@ -66,7 +70,7 @@ function createTable<T extends Entity>() {
   return methods;
 }
 
-function createLifeSpanRelations(): [EntityEvent, EntityEvent] {
+function createLifeSpanRelations(id: string): [EntityEvent, EntityEvent] {
   const dateOfBirth = faker.date.between(
     new Date(Date.UTC(1800, 0, 1)),
     new Date(Date.UTC(1930, 11, 31)),
@@ -78,11 +82,15 @@ function createLifeSpanRelations(): [EntityEvent, EntityEvent] {
       type: 'beginning',
       date: dateOfBirth.toISOString(),
       placeId: faker.helpers.arrayElement(db.place.getIds()),
+      id: faker.datatype.uuid(),
+      targetId: id,
     },
     {
       type: 'end',
       date: dateOfDeath.toISOString(),
       placeId: faker.helpers.arrayElement(db.place.getIds()),
+      id: faker.datatype.uuid(),
+      targetId: id,
     },
   ];
 }
@@ -93,6 +101,7 @@ function createPersonEvent(type: EventType, targetId: Entity['id'], date?: Date)
       type,
       targetId,
       placeId: faker.helpers.arrayElement(db.place.getIds()),
+      id: faker.datatype.uuid(),
     };
   } else {
     return {
@@ -100,6 +109,7 @@ function createPersonEvent(type: EventType, targetId: Entity['id'], date?: Date)
       targetId,
       placeId: faker.helpers.arrayElement(db.place.getIds()),
       date: date.toISOString(),
+      id: faker.datatype.uuid(),
     };
   }
 }
@@ -122,6 +132,7 @@ function createExtraRelations(birth: Date, death: Date): Array<EntityEvent> {
       date: faker.date.between(birth, death).toISOString(),
       type: faker.helpers.arrayElement(lifetimeEventTypes),
       placeId: faker.helpers.arrayElement(db.place.getIds()),
+      id: faker.datatype.uuid(),
     });
   }
   for (let i = 0; i < numAfterDeath; ++i) {
@@ -129,6 +140,7 @@ function createExtraRelations(birth: Date, death: Date): Array<EntityEvent> {
       date: faker.date.future(60, death).toISOString(),
       type: faker.helpers.arrayElement(afterDeathEventTypes),
       placeId: faker.helpers.arrayElement(db.place.getIds()),
+      id: faker.datatype.uuid(),
     });
   }
 
@@ -153,12 +165,13 @@ export function seed() {
   });
 
   times(100).forEach(() => {
+    const id = faker.datatype.uuid();
     db.person.create({
-      id: faker.datatype.uuid(),
+      id: id,
       kind: 'person',
       name: faker.name.findName(),
       description: faker.lorem.paragraph(6),
-      history: createLifeSpanRelations(),
+      history: createLifeSpanRelations(id),
       gender: faker.name.gender(true),
       categories: faker.helpers.uniqueArray(categories, faker.datatype.number({ min: 1, max: 4 })),
       occupation: faker.helpers.uniqueArray(occupations, faker.datatype.number({ min: 1, max: 3 })),

--- a/src/mocks/db.ts
+++ b/src/mocks/db.ts
@@ -44,7 +44,9 @@ function createTable<T extends Entity>() {
       if (entity.history == null) {
         entity.history = [];
       }
-      entity.history.push(relation);
+      const newRelation = { ...relation, targetId: id.toString() } as EntityEvent;
+
+      entity.history.push(newRelation);
     },
     getDistribution(property: string) {
       const entities = Array.from(table.values());

--- a/src/pages/storycreator/[id].page.tsx
+++ b/src/pages/storycreator/[id].page.tsx
@@ -1,15 +1,23 @@
-import { Container } from '@mui/material';
 import { PageMetadata } from '@stefanprobst/next-page-metadata';
+import { Allotment } from 'allotment';
 import { useRouter } from 'next/router';
-import { Fragment, useEffect } from 'react';
+import { Fragment, useEffect, useState } from 'react';
+import ReactResizeDetector from 'react-resize-detector';
 
 import { useI18n } from '@/app/i18n/use-i18n';
 import { withDictionaries } from '@/app/i18n/with-dictionaries';
 import { usePageTitleTemplate } from '@/app/metadata/use-page-title-template';
 import { useParams } from '@/app/route/use-params';
-import { useAppSelector } from '@/app/store';
-import { StoryCreator } from '@/features/storycreator/StoryCreator';
-import { selectStories } from '@/features/storycreator/storycreator.slice';
+import { useAppDispatch, useAppSelector } from '@/app/store';
+import { CollectionPanel } from '@/features/entities/collection-panel';
+import { StoryCenterPane } from '@/features/storycreator/story-center-pane';
+import { createSlide, selectStories } from '@/features/storycreator/storycreator.slice';
+import { StoryFlow } from '@/features/storycreator/StoryFlow';
+import { VisualizationDragger } from '@/features/storycreator/visualization-dragger';
+import AllotmentHeader from '@/features/ui/AllotmentHeader';
+import Button from '@/features/ui/Button';
+import { centerPaneProps, leftPaneProps, rightPaneProps } from '@/features/ui/panes.config';
+import { selectPaneOpen } from '@/features/ui/ui.slice';
 
 export const getServerSideProps = withDictionaries(['common']);
 
@@ -28,11 +36,33 @@ export default function StoryPage(): JSX.Element {
 }
 
 function StoryScreen(): JSX.Element | null {
+  const { t } = useI18n<'common'>();
+  const titleTemplate = usePageTitleTemplate();
+  const metadata = { title: t(['common', 'search', 'metadata', 'title']) };
   const router = useRouter();
   const params = useParams();
   const stories = useAppSelector(selectStories);
   const id = params?.get('id');
   const story = id != null ? stories[id] : null;
+
+  const leftPaneOpen = useAppSelector((state) => {
+    return selectPaneOpen(state, 'stc', 'left');
+  });
+
+  const rightPaneOpen = useAppSelector((state) => {
+    return selectPaneOpen(state, 'stc', 'right');
+  });
+
+  const dispatch = useAppDispatch();
+
+  const [openUpperPanel, setOpenUpperPanel] = useState(true);
+  const [openBottomPanel, setOpenBottomPanel] = useState(true);
+
+  const [openLeftUpperPanel, setOpenLeftUpperPanel] = useState(true);
+  const [openLeftBottomPanel, setOpenLeftBottomPanel] = useState(true);
+
+  const [desktop, setDesktop] = useState(true);
+  const [timescale, setTimescale] = useState(false);
 
   useEffect(() => {
     /** Router is not ready yet. */
@@ -48,8 +78,123 @@ function StoryScreen(): JSX.Element | null {
   }
 
   return (
-    <Container maxWidth={false} sx={{ height: '95vh', display: 'grid', gap: 4, padding: 4 }}>
-      <StoryCreator story={story} />
-    </Container>
+    <Fragment>
+      <PageMetadata title={metadata.title} titleTemplate={titleTemplate} />
+      <Allotment>
+        <Allotment.Pane
+          className="grid overflow-hidden overflow-y-scroll"
+          visible={leftPaneOpen}
+          {...leftPaneProps}
+          preferredSize="20%"
+        >
+          <Allotment vertical={true} proportionalLayout={false}>
+            <Allotment.Pane
+              key={`leftUpperPanel${openLeftUpperPanel}`}
+              minSize={24}
+              preferredSize={openLeftUpperPanel ? '35%' : 24}
+            >
+              <div className="grid h-full grid-cols-1 grid-rows-[max-content_1fr]">
+                <AllotmentHeader
+                  title="Collections"
+                  open={openLeftUpperPanel}
+                  onClick={() => {
+                    setOpenLeftUpperPanel(!openLeftUpperPanel);
+                  }}
+                />
+                <div className="overflow-hidden overflow-y-scroll">Collections</div>
+              </div>
+            </Allotment.Pane>
+            <Allotment.Pane
+              key={`leftBottomPanel${openLeftBottomPanel}`}
+              minSize={24}
+              preferredSize={openLeftBottomPanel ? '65%' : 24}
+            >
+              <AllotmentHeader
+                title="Entities & Events"
+                open={openLeftBottomPanel}
+                onClick={() => {
+                  setOpenLeftBottomPanel(!openLeftBottomPanel);
+                }}
+              />
+              <CollectionPanel draggable mini />
+            </Allotment.Pane>
+          </Allotment>
+        </Allotment.Pane>
+        <Allotment.Pane {...centerPaneProps}>
+          <StoryCenterPane
+            story={story}
+            desktop={desktop}
+            onDesktopChange={setDesktop}
+            timescale={timescale}
+            onTimescaleChange={setTimescale}
+          />
+        </Allotment.Pane>
+        <Allotment.Pane
+          className="grid overflow-hidden overflow-y-scroll"
+          visible={rightPaneOpen}
+          {...rightPaneProps}
+        >
+          <Allotment vertical={true} proportionalLayout={false}>
+            <Allotment.Pane
+              key={`upperPanel${openUpperPanel}`}
+              minSize={24}
+              preferredSize={openUpperPanel ? '50%' : 24}
+            >
+              <div className="grid h-full grid-cols-1 grid-rows-[max-content_1fr]">
+                <AllotmentHeader
+                  title="Story Flow"
+                  open={openUpperPanel}
+                  onClick={() => {
+                    setOpenUpperPanel(!openUpperPanel);
+                  }}
+                />
+                <div className="overflow-hidden overflow-y-scroll">
+                  <ReactResizeDetector handleWidth handleHeight>
+                    {({ width, height, targetRef }) => {
+                      return (
+                        <StoryFlow
+                          story={story}
+                          vertical={true}
+                          width={width}
+                          height={height}
+                          targetRef={targetRef}
+                        />
+                      );
+                    }}
+                  </ReactResizeDetector>
+                </div>
+                <div className="flex justify-center border-t border-intavia-gray-200 p-1">
+                  <Button
+                    border={false}
+                    round="pill"
+                    color="accent"
+                    size="small"
+                    onClick={() => {
+                      dispatch(createSlide(story.id));
+                    }}
+                  >
+                    <b>+</b> Add Slide
+                  </Button>
+                </div>
+              </div>
+            </Allotment.Pane>
+            <Allotment.Pane
+              key={`bottomPanel${openBottomPanel}`}
+              minSize={24}
+              preferredSize={openBottomPanel ? '35%' : 24}
+            >
+              <AllotmentHeader
+                title="Visualizations"
+                open={openBottomPanel}
+                onClick={() => {
+                  setOpenBottomPanel(!openBottomPanel);
+                }}
+              />
+              <VisualizationDragger />
+            </Allotment.Pane>
+          </Allotment>
+        </Allotment.Pane>
+      </Allotment>
+    </Fragment>
   );
 }

--- a/src/pages/storycreator/[id].page.tsx
+++ b/src/pages/storycreator/[id].page.tsx
@@ -184,7 +184,7 @@ function StoryScreen(): JSX.Element | null {
               preferredSize={openBottomPanel ? '35%' : 24}
             >
               <AllotmentHeader
-                title="Visualizations"
+                title="Contents"
                 open={openBottomPanel}
                 onClick={() => {
                   setOpenBottomPanel(!openBottomPanel);

--- a/src/pages/ui-test.page.tsx
+++ b/src/pages/ui-test.page.tsx
@@ -7,6 +7,7 @@ import {
   RefreshIcon,
 } from '@heroicons/react/solid';
 import { Fragment } from 'react';
+import { theme } from 'tailwind.config.cjs';
 
 import { withDictionaries } from '@/app/i18n/with-dictionaries';
 import type { FullButtonProperties } from '@/features/ui/Button';
@@ -48,6 +49,8 @@ export default function UiTestPage(): JSX.Element {
     { title: 'No border, large shadow', border: false, shadow: 'large' },
     { title: 'Border, large shadow', border: true, shadow: 'large' },
   ];
+
+  const colors = theme?.extend?.colors as Record<string, Record<string, string>>;
 
   const buttonData: Array<[string, Partial<FullButtonProperties>]> = [];
   rowProperties.forEach((row, i) => {
@@ -133,6 +136,36 @@ export default function UiTestPage(): JSX.Element {
           <ButtonLink href="#" size="large" round="circle" color="warning" shadow="large">
             <HomeIcon className="h-10 w-10" />
           </ButtonLink>
+        </div>
+      </section>
+
+      <section>
+        <h2 className="m-2 mx-4 text-xl font-semibold text-gray-700">Colors</h2>
+
+        <div className="my-10 flex w-full">
+          <div className="m-2 grid w-full grid-cols-6 grid-rows-1 place-items-center gap-4">
+            {Object.keys(colors).map((color: string) => {
+              const colorObject = (colors[color] ? colors[color] : {}) as Record<string, string>;
+              return (
+                <div key={`${color}`} className="w-full">
+                  <div className={`text-center font-semibold`}>{color}</div>
+                  {Object.keys(colorObject).map((value) => {
+                    const colorCode = colorObject[value];
+                    return (
+                      <div key={`${color}${value}wrapper`} className="m-1 table">
+                        <div className="m-2 table-cell p-1">{value}</div>
+                        <div
+                          style={{ backgroundColor: colorCode }}
+                          key={`${color}${value}`}
+                          className="table-cell w-full"
+                        />
+                      </div>
+                    );
+                  })}
+                </div>
+              );
+            })}
+          </div>
         </div>
       </section>
 

--- a/src/pages/visual-analytics-studio.page.tsx
+++ b/src/pages/visual-analytics-studio.page.tsx
@@ -1,16 +1,20 @@
 import { Allotment } from 'allotment';
 
 import { withDictionaries } from '@/app/i18n/with-dictionaries';
-import { useAppSelector } from '@/app/store';
+import { useAppDispatch, useAppSelector } from '@/app/store';
 import { CollectionEntitiesList } from '@/features/data-view-panel/data-view-panel';
+import type { LayoutOptionData } from '@/features/ui/analyse-page-toolbar/layout-popover';
 import AnalysePageToolbar from '@/features/ui/analyse-page-toolbar/toolbar';
 import DisclosureWrapper from '@/features/ui/DisclosureWrapper';
 import { centerPaneProps, leftPaneProps, rightPaneProps } from '@/features/ui/panes.config';
 import { selectPaneOpen } from '@/features/ui/ui.slice';
+import Workspaces from '@/features/visualization-layouts/workspaces';
+import { setLayoutForCurrentWorkspace } from '@/features/visualization-layouts/workspaces.slice';
 
 export const getStaticProps = withDictionaries(['common']);
 
 export default function AnalysePage(): JSX.Element {
+  const dispatch = useAppDispatch();
   const leftPaneOpen = useAppSelector((state) => {
     return selectPaneOpen(state, 'vas', 'left');
   });
@@ -18,6 +22,10 @@ export default function AnalysePage(): JSX.Element {
   const rightPaneOpen = useAppSelector((state) => {
     return selectPaneOpen(state, 'vas', 'right');
   });
+
+  const onLayoutSelected = (key: LayoutOptionData['key']) => {
+    dispatch(setLayoutForCurrentWorkspace(key));
+  };
 
   return (
     <Allotment>
@@ -28,11 +36,10 @@ export default function AnalysePage(): JSX.Element {
         <DisclosureWrapper title="Search History" defaultOpen={true}></DisclosureWrapper>
       </Allotment.Pane>
       <Allotment.Pane {...centerPaneProps}>
-        <AnalysePageToolbar
-          onLayoutSelected={() => {
-            console.log('Yay, you selected a layout, good job!');
-          }}
-        />
+        <div className="flex h-full w-full flex-col bg-red-100">
+          <AnalysePageToolbar onLayoutSelected={onLayoutSelected} />
+          <Workspaces />
+        </div>
       </Allotment.Pane>
       <Allotment.Pane visible={rightPaneOpen} {...rightPaneProps}>
         <DisclosureWrapper title="Test" defaultOpen={true}>


### PR DESCRIPTION
I tried to merge the changes of the visualisation slice into the story creator progress. Some features like switching two visualisations by drag and drop are already possible, some feature are still missing:

- The interface Visualisation and each visualization needs some Properties (similar to StoryContentProperty) to adjust them in the module dialog.
- The way how to specify entities AND entity events AND story events needs to be homogenised.
      - Therefore the entity events and story events should have an ID and should be indexed in the store for easier and faster access
- Best greetings 