### PR TITLE
Feat/data panel/visualized

### DIFF
--- a/src/features/common/visualization.slice.ts
+++ b/src/features/common/visualization.slice.ts
@@ -292,6 +292,7 @@ export const visualizationSlice = createSlice({
             },
             entityIds: [],
             targetEntityIds: [],
+            // eventIds: [],
           };
           break;
         }
@@ -342,6 +343,85 @@ export const visualizationSlice = createSlice({
         state[visId]!.eventIds.push(event.id);
       }
     },
+    removeEntityFromVisualization: (
+      state,
+      action: PayloadAction<{ visId: Visualization['id']; entity: Entity['id'] }>,
+    ) => {
+      const { visId, entity } = action.payload;
+      const vis = state[visId];
+      assert(vis != null);
+      const index = vis.entityIds.indexOf(entity);
+      if (index >= 0) {
+        vis.entityIds.splice(index, 1);
+      }
+    },
+    removeEntitiesFromVisualization: (
+      state,
+      action: PayloadAction<{ visId: Visualization['id']; entities: Array<Entity['id']> }>,
+    ) => {
+      const { visId, entities } = action.payload;
+      const vis = state[visId];
+      assert(vis != null);
+      entities.forEach((enitytId) => {
+        const index = vis.entityIds.indexOf(enitytId);
+        if (index >= 0) {
+          vis.entityIds.splice(index, 1);
+        }
+      });
+    },
+    removeEventFromVisualization: (
+      state,
+      action: PayloadAction<{ visId: Visualization['id']; event: Event['id'] }>,
+    ) => {
+      const { visId, event } = action.payload;
+      const vis = state[visId];
+      assert(vis != null);
+      const index = vis.eventIds.indexOf(event);
+      if (index >= 0) {
+        vis.eventIds.splice(index, 1);
+      }
+    },
+    removeEventsFromVisualization: (
+      state,
+      action: PayloadAction<{ visId: Visualization['id']; events: Array<Event['id']> }>,
+    ) => {
+      const { visId, events } = action.payload;
+      const vis = state[visId];
+      assert(vis != null);
+      events.forEach((eventId) => {
+        const index = vis.eventIds.indexOf(eventId);
+        if (index >= 0) {
+          vis.eventIds.splice(index, 1);
+        }
+      });
+    },
+    removeAllEntitiesFromVisualization: (
+      state,
+      action: PayloadAction<{ visId: Visualization['id'] }>,
+    ) => {
+      const { visId } = action.payload;
+      const vis = state[visId];
+      assert(vis != null);
+      vis.entityIds = [];
+    },
+    removeAllEventsFromVisualization: (
+      state,
+      action: PayloadAction<{ visId: Visualization['id'] }>,
+    ) => {
+      const { visId } = action.payload;
+      const vis = state[visId];
+      assert(vis != null);
+      vis.eventIds = [];
+    },
+    removeAllTargetEntitiesFromVisualization: (
+      state,
+      action: PayloadAction<{ visId: Visualization['id'] }>,
+    ) => {
+      const { visId } = action.payload;
+      const vis = state[visId];
+      assert(vis != null);
+      vis.targetEntityIds = [];
+    },
     editVisualization: (state, action) => {
       const vis = action.payload as Visualization;
       state[vis.id] = vis;
@@ -383,6 +463,11 @@ export const {
   addTargetEntitiesToVisualization,
   addEventToVisualization,
   addPersonToVisualization,
+  removeEntitiesFromVisualization,
+  removeAllEntitiesFromVisualization,
+  removeEventsFromVisualization,
+  removeAllEventsFromVisualization,
+  removeAllTargetEntitiesFromVisualization,
   editVisualization,
   setMapViewState,
   setMapStyle,

--- a/src/features/data-panel/data-panel.tsx
+++ b/src/features/data-panel/data-panel.tsx
@@ -1,12 +1,78 @@
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@intavia/ui';
+import { useContext, useMemo } from 'react';
 
+import { PageContext } from '@/app/context/page.context';
+import { useAppSelector } from '@/app/store';
+import type { Visualization } from '@/features/common/visualization.slice';
 import { CollectionPanel } from '@/features/data-panel/collection-panel';
 import { VisualizedPanel } from '@/features/data-panel/visualized-panel';
+import type { Story } from '@/features/storycreator/storycreator.slice';
+import { selectStories } from '@/features/storycreator/storycreator.slice';
+import { selectAllWorkspaces } from '@/features/visualization-layouts/workspaces.slice';
 
 export function DataPanel(): JSX.Element {
+  const pageContext = useContext(PageContext);
+
+  const workspaces = useAppSelector(selectAllWorkspaces);
+  const stories: Record<Story['id'], Story> = useAppSelector(selectStories);
+
+  const { currentVisualizationIds, targetHasVisualizations } = useMemo(() => {
+    const currentWorkspace = workspaces.workspaces[workspaces.currentWorkspace];
+
+    const currentSlide =
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      pageContext.page === 'story-creator' && stories != null
+        ? Object.values(stories[pageContext.storyId].slides).filter((slide) => {
+            return slide.selected;
+          })[0]
+        : null;
+
+    let currentVisualizationIds: Array<Visualization['id'] | null> | null = null;
+    let targetHasVisualizations = false;
+    switch (pageContext.page) {
+      case 'visual-analytics-studio':
+        currentVisualizationIds = Object.values(currentWorkspace!.visualizationSlots);
+        break;
+      case 'story-creator':
+        currentVisualizationIds =
+          currentSlide != null ? Object.values(currentSlide!.visualizationSlots) : null;
+        break;
+    }
+
+    if (currentVisualizationIds != null) {
+      targetHasVisualizations = !currentVisualizationIds.every((visId) => {
+        return visId === null;
+      });
+    }
+
+    return { currentVisualizationIds, targetHasVisualizations };
+  }, [
+    pageContext.page,
+    pageContext.storyId,
+    stories,
+    workspaces.currentWorkspace,
+    workspaces.workspaces,
+  ]);
+
   const tabs = {
-    collections: { label: 'Collections', panel: <CollectionPanel /> },
-    visualised: { label: 'Visualized', panel: <VisualizedPanel /> },
+    collections: {
+      label: 'Collections',
+      panel: (
+        <CollectionPanel
+          currentVisualizationIds={currentVisualizationIds}
+          targetHasVisualizations={targetHasVisualizations}
+        />
+      ),
+    },
+    visualised: {
+      label: 'Visualized',
+      panel: (
+        <VisualizedPanel
+          currentVisualizationIds={currentVisualizationIds}
+          targetHasVisualizations={targetHasVisualizations}
+        />
+      ),
+    },
   };
 
   return (

--- a/src/features/data-panel/data-view.tsx
+++ b/src/features/data-panel/data-view.tsx
@@ -17,6 +17,8 @@ interface DataViewProps {
   showChronolgyOnly?: boolean;
   targetHasVisualizations?: boolean;
   currentVisualizationIds?: Array<Visualization['id'] | null> | null;
+  mode?: 'add' | 'remove';
+  context: 'collections' | 'visualized';
 }
 
 export function DataView(props: DataViewProps): JSX.Element {
@@ -27,6 +29,8 @@ export function DataView(props: DataViewProps): JSX.Element {
     showChronolgyOnly = false,
     targetHasVisualizations = false,
     currentVisualizationIds = null,
+    mode = 'add',
+    context,
   } = props;
   const { plural, t } = useI18n<'common'>();
   // PrepData / Sort
@@ -82,6 +86,8 @@ export function DataView(props: DataViewProps): JSX.Element {
                     icon={<EntityKindIcon kind={item.kind as EntityKind} />}
                     currentVisualizationIds={currentVisualizationIds}
                     targetHasVisualizations={targetHasVisualizations}
+                    mode={mode}
+                    context={context}
                   />
                 );
               case 'event':
@@ -90,6 +96,8 @@ export function DataView(props: DataViewProps): JSX.Element {
                     event={item}
                     currentVisualizationIds={currentVisualizationIds}
                     targetHasVisualizations={targetHasVisualizations}
+                    mode={mode}
+                    context={context}
                   />
                 );
               case 'group':

--- a/src/features/data-panel/visualization-select.tsx
+++ b/src/features/data-panel/visualization-select.tsx
@@ -1,0 +1,62 @@
+import { Label, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@intavia/ui';
+
+import { useAppSelector } from '@/app/store';
+import { FormField } from '@/components/form-field';
+import type { Visualization } from '@/features/common/visualization.slice';
+import { selectAllVisualizations } from '@/features/common/visualization.slice';
+
+interface VisualizationSelectProps {
+  all?: boolean;
+  visualizationIds: Array<Visualization['id']>;
+  onChange: (visualizations: Array<Visualization['id']>) => void;
+}
+export function VisualizationSelect(props: VisualizationSelectProps): JSX.Element {
+  const { all = false, visualizationIds, onChange } = props;
+
+  const _visualizations = useAppSelector(selectAllVisualizations);
+  const visualizations = visualizationIds
+    .map((visualizationId) => {
+      const visualization = _visualizations[visualizationId];
+      if (visualization == null) return null;
+      return [
+        visualizationId,
+        `${visualization.type}: ${visualization.properties.name.value || visualization.id}`,
+      ];
+    })
+    .filter(Boolean);
+
+  const items: Array<[string, string]> = all
+    ? [['all', 'All visualizations'], ...visualizations]
+    : visualizations;
+
+  function onValueChange(value: string) {
+    if (value === 'all') {
+      onChange(
+        visualizations.map((visualization) => {
+          return visualization[0];
+        }),
+      );
+    } else {
+      onChange([value]);
+    }
+  }
+  return (
+    <FormField>
+      <Label htmlFor="visualization">Visualiztions:</Label>
+      <Select name="visualization" onValueChange={onValueChange} defaultValue={'all'}>
+        <SelectTrigger>
+          <SelectValue placeholder="Select a visualization" />
+        </SelectTrigger>
+        <SelectContent>
+          {items.map(([id, name]) => {
+            return (
+              <SelectItem key={id} value={id}>
+                {name}
+              </SelectItem>
+            );
+          })}
+        </SelectContent>
+      </Select>
+    </FormField>
+  );
+}

--- a/src/features/data-panel/visualized-panel.tsx
+++ b/src/features/data-panel/visualized-panel.tsx
@@ -1,3 +1,174 @@
-export function VisualizedPanel(): JSX.Element {
-  return <p>visualized-panel</p>;
+import { TrashIcon } from '@heroicons/react/outline';
+import type { Entity, Event } from '@intavia/api-client';
+import { Button, IconButton, Label } from '@intavia/ui';
+import type { MouseEvent } from 'react';
+import { useMemo, useState } from 'react';
+
+import { useAppDispatch, useAppSelector } from '@/app/store';
+import type { Visualization } from '@/features/common/visualization.slice';
+import {
+  removeAllEntitiesFromVisualization,
+  removeAllEventsFromVisualization,
+  removeAllTargetEntitiesFromVisualization,
+  selectAllVisualizations,
+} from '@/features/common/visualization.slice';
+import { DataView } from '@/features/data-panel/data-view';
+import { VisualizationSelect } from '@/features/data-panel/visualization-select';
+import { unique } from '@/lib/unique';
+import { useEntities } from '@/lib/use-entities';
+import { useEvents } from '@/lib/use-events';
+
+interface VisualizedPanelProps {
+  targetHasVisualizations?: boolean;
+  currentVisualizationIds?: Array<Visualization['id'] | null> | null;
+}
+
+export function VisualizedPanel(props: VisualizedPanelProps): JSX.Element {
+  const { currentVisualizationIds = null, targetHasVisualizations = false } = props;
+  const dispatch = useAppDispatch();
+  const [selectedVisualizations, setSelectedVisualizations] = useState<Array<Visualization['id']>>(
+    currentVisualizationIds != null ? currentVisualizationIds.filter(Boolean) : [],
+  );
+
+  const visualizations = useAppSelector(selectAllVisualizations);
+
+  const { entityIds, eventIds } = useMemo(() => {
+    const entityIds: Array<Entity['id']> = [];
+    const eventIds: Array<Event['id']> = [];
+
+    // console.log(selectedVisualizations);
+
+    selectedVisualizations.forEach((visualizationId) => {
+      const visualization = visualizations[visualizationId];
+      // console.log(visualization);
+      entityIds.push(...visualization?.entityIds);
+      eventIds.push(...visualization?.eventIds);
+    });
+    return { entityIds: unique(entityIds), eventIds: unique(eventIds) };
+  }, [selectedVisualizations, visualizations]);
+
+  const onVisualizationChange = (visualizations: Array<Visualization['id']>) => {
+    setSelectedVisualizations(visualizations);
+  };
+
+  const _entities = useEntities(entityIds).data;
+  const _events = useEvents(eventIds).data;
+
+  const entities = Array.from(_entities.values());
+  const events = Array.from(_events.values());
+
+  function removeAllEntitiesFromVisualizations() {
+    if (selectedVisualizations.length === 0) return;
+    for (const visualizationId of selectedVisualizations) {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      if (visualizationId != null) {
+        dispatch(removeAllEntitiesFromVisualization({ visId: visualizationId }));
+      }
+    }
+  }
+
+  function removeAllEventsFromVisualizations() {
+    if (selectedVisualizations.length === 0) return;
+    for (const visualizationId of selectedVisualizations) {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      if (visualizationId != null) {
+        dispatch(removeAllEventsFromVisualization({ visId: visualizationId }));
+        dispatch(removeAllTargetEntitiesFromVisualization({ visId: visualizationId }));
+      }
+    }
+  }
+
+  if (!targetHasVisualizations) {
+    return (
+      <div className="p-3">
+        <Button className="flex w-full place-content-center gap-2" type="button" variant="outline">
+          Please add a visualization
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col gap-1 overflow-hidden">
+      <div className="p-2">
+        <VisualizationSelect
+          all={true}
+          visualizationIds={currentVisualizationIds as Array<string>}
+          onChange={onVisualizationChange}
+        />
+      </div>
+
+      {entities != null && events != null && entities.length === 0 && events.length === 0 && (
+        <div className="p-3">
+          <Button
+            className="flex w-full place-content-center gap-2"
+            type="button"
+            variant="outline"
+          >
+            Please add data to the selected visualization
+          </Button>
+        </div>
+      )}
+
+      {entities.length > 0 && (
+        <>
+          <div className="flex flex-row items-center justify-between bg-neutral-400 p-2">
+            <Label className="text-neutral-100">Entities</Label>
+            <IconButton
+              className="h-5 w-5"
+              variant="destructive"
+              label="remove"
+              onClick={(e: MouseEvent<HTMLButtonElement>) => {
+                removeAllEntitiesFromVisualizations();
+                e.preventDefault();
+              }}
+            >
+              <TrashIcon aria-hidden="true" className="h-3 w-3 shrink-0" />
+            </IconButton>
+          </div>
+
+          <DataView
+            entities={entities}
+            events={[]}
+            groupByEntityKind={false}
+            showChronolgyOnly={false}
+            targetHasVisualizations={targetHasVisualizations}
+            currentVisualizationIds={selectedVisualizations}
+            mode={'remove'}
+            context={'visualized'}
+          />
+        </>
+      )}
+
+      {events.length > 0 && (
+        <>
+          <div className="flex flex-row items-center justify-between bg-neutral-400 p-2">
+            <Label className="text-neutral-100">Events</Label>
+            <IconButton
+              className="h-5 w-5"
+              variant="destructive"
+              label="remove"
+              onClick={(e: MouseEvent<HTMLButtonElement>) => {
+                removeAllEventsFromVisualizations();
+                // console.log('REMOVE ALL EVENTS');
+                e.preventDefault();
+              }}
+            >
+              <TrashIcon aria-hidden="true" className="h-3 w-3 shrink-0" />
+            </IconButton>
+          </div>
+          <DataView
+            entities={[]}
+            events={events}
+            groupByEntityKind={false}
+            showChronolgyOnly={true}
+            targetHasVisualizations={targetHasVisualizations}
+            currentVisualizationIds={selectedVisualizations}
+            mode={'remove'}
+            context={'visualized'}
+          />
+        </>
+      )}
+    </div>
+  );
 }


### PR DESCRIPTION
visualized tab to remove information from visualizations
splits into entities and events (due to how we store entities and events in a visualization)

It is a start, but requires some more work (not just removing but filtering)

overall maybe it does make more sense to somehow integrate the collection and visualized panel?

ToDo:

- When visualizations are removed, properly update the panel
- ...