### PR TITLE
fix: fix geomap bug caused by typo

### DIFF
--- a/src/features/geo-map/geo-map-wrapper.tsx
+++ b/src/features/geo-map/geo-map-wrapper.tsx
@@ -123,7 +123,7 @@ export function GeoMapWrapper(props: GeoMapWrapperProps): JSX.Element {
       <GeoMap
         key={visualization.id + 'GeoMap'}
         {...base}
-        i_initialViewState={viewState}
+        initialViewState={viewState}
         mapStyle={mapStyle}
         onMoveEnd={onMoveEnd}
       >

--- a/src/features/geo-map/geo-map.tsx
+++ b/src/features/geo-map/geo-map.tsx
@@ -16,13 +16,13 @@ export type GeoMapProps = Omit<MapProps, 'mapLib'>;
  * Geo-visualisation.
  */
 export const GeoMap = forwardRef<MapRef, GeoMapProps>(function GeoMap(props, ref): JSX.Element {
-  const { children, i_initialViewState } = props;
+  const { children, initialViewState } = props;
 
   const [element, setElement] = useElementRef();
 
-  const [viewState, setViewState] = useState(i_initialViewState ?? defaultMapState);
+  const [viewState, setViewState] = useState(initialViewState ?? defaultMapState);
   const [zoomLevel, setZoomlevel] = useState(
-    i_initialViewState != null ? i_initialViewState.zoom : 2.0,
+    initialViewState != null ? initialViewState.zoom : 2.0,
   );
 
   return (


### PR DESCRIPTION
Changed GeoMap i_initialViewState to initialViewState since the former doesn't exist in the GeoMapProp interface. This caused a bug when opening the detail page of a place with geometry and without relations.

Comment: please merge before Ljubljana workshop

closes #250 